### PR TITLE
Set Content-Length in response

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ const gm = require("gm");
     try {
       const data = await fs.readFile(config.outputPath);
       console.log("Image was accessed");
+      response.setHeader("Content-Length", Buffer.byteLength(data));
       response.writeHead(200, { "Content-Type": "image/png" });
       response.end(data);
     } catch (e) {


### PR DESCRIPTION
Set Content-Length in the response headers. This automatically disables node's support for chunked content, which basic HTTP clients (like Arduino) don't support.