### PR TITLE
render image on startup before cron

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ const gm = require("gm");
     );
     renderAndConvertAsync(browser);
   } else {
+    console.log("Starting first render...");
+    renderAndConvertAsync(browser);
     console.log("Starting rendering cronjob...");
     new CronJob({
       cronTime: config.cronJob,


### PR DESCRIPTION
When the container first starts it may take a while (depending on cron setting) to render the screenshots for the first time.

This change performs an initial render on startup, and then performs all future renders according to the cron setting.