### PR TITLE
Add option to control image black and white levels.

### DIFF
--- a/config.js
+++ b/config.js
@@ -25,6 +25,8 @@ function getPagesConfig() {
         width: getEnvironmentVariable("RENDERING_SCREEN_WIDTH", suffix) || 600,
       },
       grayscaleDepth: getEnvironmentVariable("GRAYSCALE_DEPTH", suffix) || 8,
+      blackLevel: getEnvironmentVariable("BLACK_LEVEL", suffix) || "0%",
+      whiteLevel: getEnvironmentVariable("WHITE_LEVEL", suffix) || "100%",
       dither: getEnvironmentVariable("DITHER", suffix) || false,
       colorMode: getEnvironmentVariable("COLOR_MODE", suffix) || "GrayScale",
       rotation: getEnvironmentVariable("ROTATION", suffix) || 0,

--- a/index.js
+++ b/index.js
@@ -303,6 +303,7 @@ function convertImageToKindleCompatiblePngAsync(
       .dither(pageConfig.dither)
       .rotate("white", pageConfig.rotation)
       .type(pageConfig.colorMode)
+      .level(pageConfig.blackLevel, pageConfig.whiteLevel)
       .bitdepth(pageConfig.grayscaleDepth)
       .quality(100)
       .write(outputPath, (err) => {


### PR DESCRIPTION
Some E-ink screens have low contrast, so changing image color levels can help with visibility.