### PR TITLE
Consider ignoreCertificateErrors when sending battery status to HA

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,8 @@ function sendBatteryLevelToHomeAssistant(
     headers: {
       "Content-Type": "application/json",
       "Content-Length": Buffer.byteLength(batteryStatus)
-    }
+    },
+    rejectUnauthorized: !config.ignoreCertificateErrors
   };
   const url = `${config.baseUrl}/api/webhook/${batteryWebHook}`;
   const httpLib = url.toLowerCase().startsWith("https") ? https : http;


### PR DESCRIPTION
HA_BATTERY_WEBHOOK sends the request to the same HA_BASE_URL as Chrome so it should consider ignoreCertificateErrors param too