### PR TITLE
Adding Home Assistant Addon 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,55 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            sibbl/hass-lovelace-kindle-screensaver:${{ env.PACKAGE_VERSION }},
-            sibbl/hass-lovelace-kindle-screensaver:latest
-      - name: Tag git commit
-        uses: pkgdeps/git-tag-action@v2
+            j3n50m4t/hass-lovelace-kindle-screensaver:${{ env.PACKAGE_VERSION }},
+            j3n50m4t/hass-lovelace-kindle-screensaver:latest
+      - name: Build and push HA_Addon AMD64 to Docker
+        uses: docker/build-push-action@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_repo: ${{ github.repository }}
-          version: ${{ env.PACKAGE_VERSION }}
-          git_commit_sha: ${{ github.sha }}
-          git_tag_prefix: "v"
+          context: .
+          file: ./Dockerfile.HA_ADDON
+          build-args: BUILD_FROM=homeassistant/amd64-base:latest
+          platforms: linux/amd64
+          push: true
+          tags: |
+            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-amd64:${{ env.PACKAGE_VERSION }},
+            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-amd64:latest
+      - name: Build and push HA_Addon aarch64 to Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.HA_ADDON
+          build-args: BUILD_FROM=homeassistant/aarch64-base:latest
+          platforms: linux/arm64
+          push: true
+          tags: |
+            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-aarch64:${{ env.PACKAGE_VERSION }},
+            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-aarch64:latest
+
+
+      # Currently fails with. I'dont know why, as build womm. Someone? 
+      #8 0.148 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/armhf/APKINDEX.tar.gz
+      #8 1.271 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/armhf/APKINDEX.tar.gz
+      #8 2.193 ERROR: unable to select packages:
+      #8 2.282   chromium (no such package):
+      #8 2.282     required by: world[chromium]  
+      # - name: Build and push HA_Addon ARMv7 to Docker
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     file: ./Dockerfile.HA_ADDON
+      #     build-args: BUILD_FROM=homeassistant/armhf-base:latest
+      #     platforms: linux/armhf
+      #     push: true
+      #     tags: |
+      #       j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-armv7:${{ env.PACKAGE_VERSION }},
+      #       j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-armv7:latest
+
+      # - name: Tag git commit
+      #   uses: pkgdeps/git-tag-action@v2
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     github_repo: ${{ github.repository }}
+      #     version: ${{ env.PACKAGE_VERSION }}
+      #     git_commit_sha: ${{ github.sha }}
+      #     git_tag_prefix: "v"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            j3n50m4t/hass-lovelace-kindle-screensaver:${{ env.PACKAGE_VERSION }},
-            j3n50m4t/hass-lovelace-kindle-screensaver:latest
+            sibbl/hass-lovelace-kindle-screensaver:${{ env.PACKAGE_VERSION }},
+            sibbl/hass-lovelace-kindle-screensaver:latest
       - name: Build and push HA_Addon AMD64 to Docker
         uses: docker/build-push-action@v2
         with:
@@ -41,8 +41,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-amd64:${{ env.PACKAGE_VERSION }},
-            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-amd64:latest
+            sibbl/hass-lovelace-kindle-screensaver-ha-addon-amd64:${{ env.PACKAGE_VERSION }},
+            sibbl/hass-lovelace-kindle-screensaver-ha-addon-amd64:latest
       - name: Build and push HA_Addon aarch64 to Docker
         uses: docker/build-push-action@v2
         with:
@@ -52,8 +52,8 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: |
-            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-aarch64:${{ env.PACKAGE_VERSION }},
-            j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-aarch64:latest
+            sibbl/hass-lovelace-kindle-screensaver-ha-addon-aarch64:${{ env.PACKAGE_VERSION }},
+            sibbl/hass-lovelace-kindle-screensaver-ha-addon-aarch64:latest
 
 
       # Currently fails with. I'dont know why, as build womm. Someone? 
@@ -71,8 +71,8 @@ jobs:
       #     platforms: linux/armhf
       #     push: true
       #     tags: |
-      #       j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-armv7:${{ env.PACKAGE_VERSION }},
-      #       j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-armv7:latest
+      #       sibbl/hass-lovelace-kindle-screensaver-ha-addon-armv7:${{ env.PACKAGE_VERSION }},
+      #       sibbl/hass-lovelace-kindle-screensaver-ha-addon-armv7:latest
 
       # - name: Tag git commit
       #   uses: pkgdeps/git-tag-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ node_modules/
 config.*.js
 docker-compose.*.yml
 cover.png
-output/
 .devcontainer/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.*.js
 docker-compose.*.yml
 cover.png
 output/
+.devcontainer/
+.DS_Store

--- a/Dockerfile.HA_ADDON
+++ b/Dockerfile.HA_ADDON
@@ -1,0 +1,33 @@
+ARG BUILD_FROM
+FROM ${BUILD_FROM} 
+
+WORKDIR /app
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    font-noto-emoji \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    imagemagick \
+    nodejs \
+    npm
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
+    USE_IMAGE_MAGICK=true
+
+COPY package*.json ./
+COPY local.conf /etc/fonts/local.conf
+COPY *.js ./
+
+RUN npm ci
+
+
+# Copy data for add-on
+COPY run.sh /
+RUN chmod a+x /run.sh
+
+CMD [ "/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Using my [own Kindle 4 setup guide](https://github.com/sibbl/hass-lovelace-kindl
 
 You may simple set up the [sibbl/hass-lovelace-kindle-screensaver](https://hub.docker.com/r/sibbl/hass-lovelace-kindle-screensaver) docker container. The container exposes a single port (5000 by default).
 
+Another way is to use Hassio Addons where you have to add this repository or click [here](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fsibbl%2Fhass-lovelace-kindle-screensaver). Then Reload and you should see options to the Lovelace Kindle Screensaver Addon
+
 I recommend simply using the `docker-compose.yml` file inside this repository, configure everything in there and run `docker-compose up -d` within the file's directory. This will pull the docker image, create the container with all environment variables from the file and run it in detached mode (using `-d`, so it continues running even when you exit your shell/bash/ssh connection).
 Additionally, you can then later use `docker-compose pull && docker-compose up -d` to update the image in case you want to update it.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,53 @@
+name: Lovelace Kindle Screensaver
+version: 1.0.4
+slug: kindle-screensaver
+description: This tool can be used to display a Lovelace view of your Home Assistant instance on a jailbroken Kindle device. It regularly takes a screenshot which can be polled and used as a screensaver image of the online screensaver plugin.
+startup: application
+boot: auto
+arch:
+  - aarch64
+  - amd64
+  # -  - See github/ci.yml
+url: 'https://github.com/J3n50m4t/hass-lovelace-kindle-screensaver'
+image: 'j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-{arch}'
+webui: 'http://[HOST]:[PORT:5000]'
+ingress: true
+ingress_port: 5000
+ports:
+  5000/tcp: 5000
+ports_description:
+  5000/tcp: 'Node Webserver hosting rendered image'
+map:
+  - media:rw
+watchdog: 'http://[HOST]:[PORT:5000]/'
+init: false
+options:
+  HA_BASE_URL: 'https://your-path-to-home-assistant:8123'
+  HA_SCREENSHOT_URL: '/lovelace/0'
+  HA_ACCESS_TOKEN: ''
+  LANGUAGE: 'en'
+  CRON_JOB: '* * * * *'
+  RENDERING_TIMEOUT: '60000'
+  RENDERING_DELAY: '0'
+  RENDERING_SCREEN_HEIGHT: '800'
+  RENDERING_SCREEN_WIDTH: '600'
+  ROTATION: '0'
+  SCALING: '1'
+  GRAYSCALE_DEPTH: '8'
+  COLOR_MODE: 'GrayScale'
+schema:
+  HA_BASE_URL: "url"
+  HA_SCREENSHOT_URL: "str"
+  HA_ACCESS_TOKEN: "password"
+  LANGUAGE: "str"
+  CRON_JOB: "str"
+  RENDERING_TIMEOUT: "int"
+  RENDERING_DELAY: "int"
+  RENDERING_SCREEN_HEIGHT: "int"
+  RENDERING_SCREEN_WIDTH: "int"
+  ROTATION: "int"
+  SCALING: "int"
+  GRAYSCALE_DEPTH: "int"
+  COLOR_MODE: "list(GrayScale|TrueColor)?"
+environment:
+  output_path: "/output/cover.png"

--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,8 @@ arch:
   - aarch64
   - amd64
   # -  - See github/ci.yml
-url: 'https://github.com/J3n50m4t/hass-lovelace-kindle-screensaver'
-image: 'j3n50m4t/hass-lovelace-kindle-screensaver-ha-addon-{arch}'
+url: 'https://github.com/sibbl/hass-lovelace-kindle-screensaver'
+image: 'sibbl/hass-lovelace-kindle-screensaver-ha-addon-{arch}'
 webui: 'http://[HOST]:[PORT:5000]'
 ingress: true
 ingress_port: 5000

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: 'Lovelace Kindle Screensaver'
-url: 'https://github.com/J3n50m4t/hass-lovelace-kindle-screensaver'
+url: 'https://github.com/sibbl/hass-lovelace-kindle-screensaver'
 maintainer: 'sibbl'

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: 'Lovelace Kindle Screensaver'
+url: 'https://github.com/J3n50m4t/hass-lovelace-kindle-screensaver'
+maintainer: 'sibbl'

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/with-contenv bashio
+
+bashio::log.info "Starting npm server..."
+
+export HA_BASE_URL="$(bashio::config 'HA_BASE_URL')"
+export HA_SCREENSHOT_URL=$(bashio::config 'HA_SCREENSHOT_URL')
+export HA_ACCESS_TOKEN="$(bashio::config 'HA_ACCESS_TOKEN')"
+export LANGUAGE=$(bashio::config 'LANGUAGE')
+export CRON_JOB=$(bashio::config 'CRON_JOB')
+export RENDERING_TIMEOUT=$(bashio::config 'RENDERING_TIMEOUT')
+export RENDERING_DELAY=$(bashio::config 'RENDERING_DELAY')
+export RENDERING_SCREEN_HEIGHT=$(bashio::config 'RENDERING_SCREEN_HEIGHT')
+export RENDERING_SCREEN_WIDTH=$(bashio::config 'RENDERING_SCREEN_WIDTH')
+export ROTATION=$(bashio::config 'ROTATION')
+export SCALING=$(bashio::config 'SCALING')
+export GRAYSCALE_DEPTH=$(bashio::config 'GRAYSCALE_DEPTH')
+export COLOR_MODE=$(bashio::config 'COLOR_MODE')
+
+bashio::log.info "Using base_url: ${HA_BASE_URL}"
+
+cd /app
+exec /usr/bin/npm start


### PR DESCRIPTION
solves #1 
I kept it simple. 
For now the Addon needs a Token as i wanted it to stay as close as possible to the main tool. 


Adding over Addon Store, the configuration in the UI is possible. 
I set an default of 60 seconds, which seems ridiculous high, but my raspi4 needed often more than 30secs and i don't wanted to get it killed all the time (i have many addons however)


[Builds before i used sibbl docker repo again](https://github.com/J3n50m4t/hass-lovelace-kindle-screensaver/actions/runs/4818764789/jobs/8581142397)
Note: I'm unable to build a build armv7. The Github action fails, it works however on my machine.. May someone with more github action experience here?  

![Bildschirmfoto 2023-04-27 um 12 04 29](https://user-images.githubusercontent.com/13681191/234838058-ce99aff6-76ff-4121-b74f-ccbeaf389538.png)

![Bildschirmfoto 2023-04-27 um 12 32 09](https://user-images.githubusercontent.com/13681191/234838077-4fa25773-c274-4091-b74d-5233d72026d7.png)

![Bildschirmfoto 2023-04-27 um 12 32 18](https://user-images.githubusercontent.com/13681191/234838092-51b26aa4-6206-4b96-95c1-de7acd190cfb.png)
