### PR TITLE
Wait until first render is done before starting up cron job.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const batteryStore = {};
     renderAndConvertAsync(browser);
   } else {
     console.log("Starting first render...");
-    renderAndConvertAsync(browser);
+    await renderAndConvertAsync(browser);
     console.log("Starting rendering cronjob...");
     new CronJob({
       cronTime: config.cronJob,


### PR DESCRIPTION
It was possible that cron job was ran while first render was still running, causing problems when two threads simultaneously wrote same output image. 

This PR makes the first render synchronous operation and starts cron job after the first image has finished.