### PR TITLE
Add option to remove Gamma correction from image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Home Assistant related stuff:
 | `GRAYSCALE_DEPTH`         | `8`                                   | no       | yes      | Grayscale bit depth your kindle supports                                                                                                               |
 | `COLOR_MODE`              | `GrayScale`                           | no       | yes      | ColorMode to use, ex: `GrayScale`, or `TrueColor`.                                                                                                      |
 | `DITHER`                  | `false`                               | no       | yes      | Apply a dither to the images.                                                                                                                           |
+| `REMOVE_GAMMA`            | `true`                                | no       | no       | Remove gamma correction from image. Computer images are normally gamma corrected since monitors expect gamma corrected data, however some E-Ink displays expect images not to have gamma correction. |
 
 **\* Array** means that you can set `HA_SCREENSHOT_URL_2`, `HA_SCREENSHOT_URL_3`, ... `HA_SCREENSHOT_URL_n` to render multiple pages within the same instance.
 If you use `HA_SCREENSHOT_URL_2`, you can also set `ROTATION_2=180`. If there is no `ROTATION_n` set, then `ROTATION` will be used as a fallback.

--- a/config.js
+++ b/config.js
@@ -25,6 +25,7 @@ function getPagesConfig() {
         width: getEnvironmentVariable("RENDERING_SCREEN_WIDTH", suffix) || 600,
       },
       grayscaleDepth: getEnvironmentVariable("GRAYSCALE_DEPTH", suffix) || 8,
+      removeGamma: getEnvironmentVariable("REMOVE_GAMMA", suffix) || false,
       blackLevel: getEnvironmentVariable("BLACK_LEVEL", suffix) || "0%",
       whiteLevel: getEnvironmentVariable("WHITE_LEVEL", suffix) || "100%",
       dither: getEnvironmentVariable("DITHER", suffix) || false,

--- a/index.js
+++ b/index.js
@@ -303,6 +303,7 @@ function convertImageToKindleCompatiblePngAsync(
       .options({
         imageMagick: config.useImageMagick === true
       })
+      .gamma(pageConfig.removeGamma ? 1.0/2.2 : 1.0)
       .dither(pageConfig.dither)
       .rotate("white", pageConfig.rotation)
       .type(pageConfig.colorMode)


### PR DESCRIPTION
Computer images are normally gamma corrected since monitors expect it. However some E-Ink displays expect linear instead gamma corrected image data.

Added new option REMOVE_GAMMA that will remove gamma correction from the image when it is set to true.

This can improve image readability on some E-Ink displays.