### PR TITLE
Fix bug in config.yaml to use non integer scaling factors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,7 +50,7 @@ schema:
   RENDERING_SCREEN_WIDTH: "int"
   BROWSER_LAUNCH_TIMEOUT: "int"
   ROTATION: "int"
-  SCALING: "int"
+  SCALING: "float"
   GRAYSCALE_DEPTH: "int"
   COLOR_MODE: "list(GrayScale|TrueColor)?"
   PREFERS_COLOR_SCHEME: "list(light|dark)?"


### PR DESCRIPTION
Replaced 'int' descriptor with 'float' in the config.yaml file.
This closes #78 