### PR TITLE
Fix Viewport resizing upon page.screenshot

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const batteryStore = {};
       `--lang=${config.language}`,
       config.ignoreCertificateErrors && "--ignore-certificate-errors"
     ].filter((x) => x),
+    defaultViewport: null,
     timeout: config.browserLaunchTimeout,
     headless: config.debug !== true
   });
@@ -280,6 +281,7 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
     await page.screenshot({
       path,
       type: pageConfig.imageFormat,
+      captureBeyondViewport: false,
       clip: {
         x: 0,
         y: 0,


### PR DESCRIPTION
**Issue**
Currently, Puppetteer resizes the viewport when `page.screenshot(...)` is being triggered. On modern development hardware, you barely notice it in non-headless mode, unless for example you manually throttle Chromium (`await page.emulateCPUThrottling(6);`). The issue with the viewport resizing is that in HomeAssistant, some dashboards reload / redraw themselves upon resize action. Which results in a beautiful race condition upon taking the screenshot. Issues like https://github.com/sibbl/hass-lovelace-kindle-screensaver/issues/95 are the consequence. The resizing seems weird and unnecessary, given that the dimensions are defined already...

**Approach**
I found a [workaround](https://stackoverflow.com/questions/68059664/puppeteer-page-screenshot-resizes-viewport) on StackOverflow how to prevent the re-sizing of the viewport. It works on my machine as expected, but please verify with your own dashboard.