### PR TITLE
Swap scale mechanism to use zoom instead of css transforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,10 +267,7 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
     await page.addStyleTag({
       content: `
         body {
-          width: calc(${size.width}px / ${pageConfig.scaling});
-          height: calc(${size.height}px / ${pageConfig.scaling});
-          transform-origin: 0 0;
-          transform: scale(${pageConfig.scaling});
+          zoom: ${pageConfig.scaling * 100}%;
           overflow: hidden;
         }`
     });


### PR DESCRIPTION
I've been having issues with Apex Charts rendering incorrectly due to the scale transform being applied to the body tag.

This pull request replaces the scale transform with zoom, which is implemented like the built in browser 'zoom' and fixes the scaling related bugs.

Before:
<img width="1024" alt="Screenshot 2024-08-06 at 20 07 24" src="https://github.com/user-attachments/assets/b783f056-0620-4352-879e-f79ce369bdc0">

After:
<img width="1076" alt="Screenshot 2024-08-06 at 20 06 32" src="https://github.com/user-attachments/assets/4fb71621-25cd-477d-ae67-48be35d0a254">
