### PR TITLE
Contrast and saturation adjust

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Home Assistant related stuff:
 | `IMAGE_FORMAT`            | `png`                                 | no       | no       | Format for the generated images. Acceptable values are `png` or `jpeg`.                                                                                                                              |
 | `DITHER`                  | `false`                               | no       | yes      | Apply a dither to the images.                                                                                                                                                                        |
 | `REMOVE_GAMMA`            | `true`                                | no       | no       | Remove gamma correction from image. Computer images are normally gamma corrected since monitors expect gamma corrected data, however some E-Ink displays expect images not to have gamma correction. |
+| SATURATION              | 2                                   | no       | no       | Saturation level multiplier, e.g. 2 doubles the saturation |
+| CONTRAST                | 2                                   | no       | no       | Contrast level multiplier, e.g. 2 doubles the contrast |
+| BLACK_LEVEL             | 30%                                 | no       | no       | Black point as percentage of MaxRGB, i.e. crushes blacks below specified level |
+| WHITE_LEVEL             | 90%                                 | no       | no       | White point as percentage of MaxRGB, i.e. crushes whites above specified level |
 
 **\* Array** means that you can set `HA_SCREENSHOT_URL_2`, `HA_SCREENSHOT_URL_3`, ... `HA_SCREENSHOT_URL_n` to render multiple pages within the same instance.
 If you use `HA_SCREENSHOT_URL_2`, you can also set `ROTATION_2=180`. If there is no `ROTATION_n` set, then `ROTATION` will be used as a fallback.

--- a/config.js
+++ b/config.js
@@ -35,6 +35,8 @@ function getPagesConfig() {
       rotation: getEnvironmentVariable("ROTATION", suffix) || 0,
       scaling: getEnvironmentVariable("SCALING", suffix) || 1,
       batteryWebHook: getEnvironmentVariable("HA_BATTERY_WEBHOOK", suffix) || null,
+      saturation: getEnvironmentVariable("SATURATION", suffix) || 1,
+      contrast: getEnvironmentVariable("CONTRAST", suffix) || 1,
     });
   }
   return pages;

--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,8 @@ options:
   REMOVE_GAMMA: true
   PREFERS_COLOR_SCHEME: 'light'
   HA_BATTERY_WEBHOOK: ''
+  SATURATION: 1
+  CONTRAST: 1
   ADDITIONAL_ENV_VARS: []
 schema:
   HA_BASE_URL: "url"
@@ -60,6 +62,8 @@ schema:
   REMOVE_GAMMA: "bool?"
   PREFERS_COLOR_SCHEME: "list(light|dark)?"
   HA_BATTERY_WEBHOOK: "str?"
+  SATURATION: "int?"
+  CONTRAST: "int?"
   ADDITIONAL_ENV_VARS:
     - name: match(^[A-Z0-9_]+$)
       value: str

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
         y: 0,
         ...size
       },
-      quality: 100
+      ...(pageConfig.imageFormat=="jpeg") && {quality: 100}
     });
   } catch (e) {
     console.error("Failed to render", e);

--- a/index.js
+++ b/index.js
@@ -283,7 +283,8 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
         x: 0,
         y: 0,
         ...size
-      }
+      },
+      quality: 100
     });
   } catch (e) {
     console.error("Failed to render", e);
@@ -304,7 +305,9 @@ function convertImageToKindleCompatiblePngAsync(
       .options({
         imageMagick: config.useImageMagick === true
       })
-      .gamma(pageConfig.removeGamma ? 1.0/2.2 : 1.0)
+      .gamma(pageConfig.removeGamma ? 1.0 / 2.2 : 1.0)
+      .modulate(100, 100 * pageConfig.saturation)
+      .contrast(pageConfig.contrast)
       .dither(pageConfig.dither)
       .rotate("white", pageConfig.rotation)
       .type(pageConfig.colorMode)


### PR DESCRIPTION
Thanks for making this tool! I've got a colour e-paper display that I'd like to use, but unfortunately the image looks a little dull using the default configuration. I've exposed the saturation and contrast controls from GraphicsMagick, adjusting these lets you get a much more vibrant image without having to adjust any home assistant themes. I also added documentation for the black and white point configuration. This gives a much better image on the e-paper screen.

Before:
![image](https://github.com/user-attachments/assets/102649aa-6f25-465d-852b-8be87ebc5768)

After: (Double saturation and contrast)
![image](https://github.com/user-attachments/assets/51a02b2b-aa5b-4895-869e-68147330823a)
