### PR TITLE
Add optional HTTP Basic Auth support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,5 @@ HA_SCREENSHOT_URL=/lovelace/screensaver?kiosk
 HA_ACCESS_TOKEN=ey...
 #DEBUG=true
 #USE_IMAGE_MAGICK=true
+#HTTP_AUTH_USER=admin
+#HTTP_AUTH_PASSWORD=secret

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+HA_BASE_URL=http://homeassistant.local
+HA_SCREENSHOT_URL=/lovelace/screensaver?kiosk
+HA_ACCESS_TOKEN=ey...
+#DEBUG=true
+#USE_IMAGE_MAGICK=true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docker-compose.*.yml
 cover.png
 .devcontainer/
 .DS_Store
+.env

--- a/config.js
+++ b/config.js
@@ -55,4 +55,6 @@ module.exports = {
   debug: process.env.DEBUG === "true",
   ignoreCertificateErrors:
     process.env.UNSAFE_IGNORE_CERTIFICATE_ERRORS === "true",
+  httpAuthUser: process.env.HTTP_AUTH_USER || null,
+  httpAuthPassword: process.env.HTTP_AUTH_PASSWORD || null,
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const config = require("./config");
 const path = require("path");
 const http = require("http");

--- a/index.js
+++ b/index.js
@@ -78,7 +78,30 @@ const batteryStore = {};
     });
   }
 
+  const requireAuth = config.httpAuthUser && config.httpAuthPassword;
+  if (requireAuth) {
+    console.log("Basic auth enabled for HTTP server");
+  }
+
   const httpServer = http.createServer(async (request, response) => {
+    // Check basic auth if configured
+    if (requireAuth) {
+      const authHeader = request.headers.authorization;
+      if (!authHeader || !authHeader.startsWith("Basic ")) {
+        response.writeHead(401, { "WWW-Authenticate": 'Basic realm="hass-lovelace-kindle-screensaver"' });
+        response.end("Unauthorized");
+        return;
+      }
+      const credentials = Buffer.from(authHeader.slice(6), "base64").toString();
+      const [user, ...passwordParts] = credentials.split(":");
+      const password = passwordParts.join(":");
+      if (user !== config.httpAuthUser || password !== config.httpAuthPassword) {
+        response.writeHead(401, { "WWW-Authenticate": 'Basic realm="hass-lovelace-kindle-screensaver"' });
+        response.end("Unauthorized");
+        return;
+      }
+    }
+
     // Parse the request
     const url = new URL(request.url, `http://${request.headers.host}`);
     // Check the page number

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cron": "^1.8.2",
+        "dotenv": "^16.6.1",
         "fs-extra": "^10.0.0",
         "gm": "^1.23.1",
         "puppeteer": "^11.0.0"
@@ -173,6 +174,18 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
       "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ=="
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -281,7 +294,6 @@
       "version": "1.23.1",
       "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
       "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
-      "deprecated": "The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained",
       "dependencies": {
         "array-parallel": "~0.1.3",
         "array-series": "~0.1.5",
@@ -542,7 +554,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-11.0.0.tgz",
       "integrity": "sha512-6rPFqN1ABjn4shgOICGDBITTRV09EjXVqhDERBDKwCLz0UyBxeeBH6Ay0vQUJ84VACmlxwzOIzVEJXThcF3aNg==",
-      "deprecated": "< 24.9.0 is no longer supported",
+      "deprecated": "< 22.8.2 is no longer supported",
       "hasInstallScript": true,
       "dependencies": {
         "debug": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "cron": "^1.8.2",
+    "dotenv": "^16.6.1",
     "fs-extra": "^10.0.0",
     "gm": "^1.23.1",
     "puppeteer": "^11.0.0"


### PR DESCRIPTION
## Summary

Adds optional Basic Authentication support for the HTTP server that serves screensaver images.

## Configuration

Set both environment variables to enable auth:

```
HTTP_AUTH_USER=admin
HTTP_AUTH_PASSWORD=secret
```

If either variable is unset, authentication is skipped (fully backward-compatible).

## Changes

- **`config.js`** — Added `httpAuthUser` and `httpAuthPassword` config from env vars
- **`index.js`** — Added Basic Auth check at the top of the HTTP request handler
- **`.env.sample`** — Documented the new optional env vars

## Details

- Returns `401 Unauthorized` with `WWW-Authenticate` header for missing/invalid credentials
- Correctly handles passwords containing colons
- Zero impact when not configured