### PR TITLE
Add image change detection with ETag/HEAD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This tool regularly takes a screenshot of a specific page of your home assistant
 
 Using my [own Kindle 4 setup guide](https://github.com/sibbl/hass-lovelace-kindle-4) or the [online screensaver extension](https://www.mobileread.com/forums/showthread.php?t=236104) for any jailbroken Kindle, this image can be regularly polled from your device so you can use it as a weather station, a display for next public transport departures etc.
 
+### Energy-efficient image updates
+
+The tool compares each new screenshot with the previous one and only updates the served image when changes are detected. This keeps the `Last-Modified` timestamp and `ETag` header stable, allowing e-ink clients to skip unnecessary downloads and screen refreshes.
+
+You can use a lightweight `HEAD` request to check for changes without downloading the image:
+
+```bash
+curl -I http://localhost:5000/
+```
+
+Compare the returned `ETag` or `Last-Modified` with your last known value — only `GET` the image if it changed.
+
 ## Usage
 
 You may simple set up the [sibbl/hass-lovelace-kindle-screensaver](https://hub.docker.com/r/sibbl/hass-lovelace-kindle-screensaver) docker container. The container exposes a single port (5000 by default).

--- a/index.js
+++ b/index.js
@@ -8,9 +8,20 @@ const fsExtra = require("fs-extra");
 const puppeteer = require("puppeteer");
 const { CronJob } = require("cron");
 const gm = require("gm");
+const crypto = require("crypto");
 
 // keep state of current battery level and whether the device is charging
 const batteryStore = {};
+
+// Helper function to calculate file hash
+async function getFileHash(filePath) {
+  try {
+    const fileBuffer = await fs.readFile(filePath);
+    return crypto.createHash('sha256').update(fileBuffer).digest('hex');
+  } catch (error) {
+    return null;
+  }
+}
 
 (async () => {
   if (config.pages.length === 0) {
@@ -125,23 +136,34 @@ const batteryStore = {};
     try {
       // Log when the page was accessed
       const n = new Date();
-      console.log(`${n.toISOString()}: Image ${pageNumber} was accessed`);
+      console.log(`${n.toISOString()}: Image ${pageNumber} was accessed (${request.method})`);
 
       const pageIndex = pageNumber - 1;
       const configPage = config.pages[pageIndex];
 
-      const outputPathWithExtension = configPage.outputPath + "." + configPage.imageFormat
+      const outputPathWithExtension = configPage.outputPath + "." + configPage.imageFormat;
       const data = await fs.readFile(outputPathWithExtension);
       const stat = await fs.stat(outputPathWithExtension);
 
       const lastModifiedTime = new Date(stat.mtime).toUTCString();
+      const etag = crypto.createHash('sha256').update(data).digest('hex');
 
-      response.writeHead(200, {
+      const headers = {
         "Content-Type": "image/" + configPage.imageFormat,
         "Content-Length": Buffer.byteLength(data),
-        "Last-Modified": lastModifiedTime
-      });
-      response.end(data);
+        "Last-Modified": lastModifiedTime,
+        "ETag": `"${etag}"`,
+        "Cache-Control": "no-cache"
+      };
+
+      // Support HEAD requests — return headers only, no body
+      if (request.method === "HEAD") {
+        response.writeHead(200, headers);
+        response.end();
+      } else {
+        response.writeHead(200, headers);
+        response.end(data);
+      }
 
       let pageBatteryStore = batteryStore[pageIndex];
       if (!pageBatteryStore) {
@@ -199,14 +221,43 @@ async function renderAndConvertAsync(browser) {
     console.log(`Rendering ${url} to image...`);
     await renderUrlToImageAsync(browser, pageConfig, url, tempPath);
 
+    if (!(await fsExtra.pathExists(tempPath))) {
+      console.error(`Screenshot missing: ${tempPath}`);
+      continue;
+    }
+
     console.log(`Converting rendered screenshot of ${url} to grayscale...`);
+
+    const finalTempPath = outputPath + ".final.temp";
     await convertImageToKindleCompatiblePngAsync(
       pageConfig,
       tempPath,
-      outputPath
+      finalTempPath
     );
 
-    fs.unlink(tempPath);
+    // Compare with existing image — only update if changed
+    let hasChanged = true;
+    if (await fsExtra.pathExists(outputPath)) {
+      const newHash = await getFileHash(finalTempPath);
+      const existingHash = await getFileHash(outputPath);
+
+      if (newHash && existingHash && newHash === existingHash) {
+        hasChanged = false;
+        console.log(`Image unchanged for ${url}, skipping update`);
+      } else {
+        console.log(`Image changed for ${url}, updating`);
+      }
+    } else {
+      console.log(`First render for ${url}, creating image`);
+    }
+
+    if (hasChanged) {
+      await fsExtra.move(finalTempPath, outputPath, { overwrite: true });
+    } else {
+      await fs.unlink(finalTempPath);
+    }
+
+    await fs.unlink(tempPath);
     console.log(`Finished ${url}`);
 
     if (
@@ -341,7 +392,10 @@ function convertImageToKindleCompatiblePngAsync(
     if (pageConfig.imageFormat !== 'bmp') {
       gmInstance = gmInstance.quality(100);
     }
-    
+
+    // Strip metadata to ensure deterministic output for hash comparison
+    gmInstance = gmInstance.strip();
+
     gmInstance.write(outputPath, (err) => {
       if (err) {
         reject(err);


### PR DESCRIPTION
## Summary

Simplified alternative to #140 — adds image change detection and proper HTTP caching headers without introducing a new JSON metadata endpoint.

### Changes

- **Image hash comparison**: SHA-256 compare new vs existing output image; only overwrite when the image actually changed. This preserves the file's `mtime`, keeping `Last-Modified` stable.
- **Metadata stripping**: `.strip()` on gm/ImageMagick output removes timestamps and other variable metadata, ensuring identical images produce identical file hashes.
- **`ETag` header**: Content hash returned on every response, enabling conditional requests.
- **`Cache-Control: no-cache`**: Forces revalidation so clients always check but can skip download if unchanged.
- **`HEAD` request support**: Clients (e.g. Kindle scripts) can `HEAD /` to get `Last-Modified`/`ETag`/`Content-Length` without downloading the image body.
- **Missing screenshot guard**: Gracefully `continue` instead of crashing when a screenshot fails to render.

### How it works for e-ink clients

Instead of a separate `/.json` metadata endpoint, clients can use standard HTTP:

```bash
# Cheap check — headers only, no image body transferred
curl -I http://localhost:5000/

# Compare ETag or Last-Modified with previous value
# Only GET if changed
```

This avoids unnecessary e-ink screen refreshes and saves bandwidth/battery.

### Related

Inspired by #140 (fixes #119) — same core idea (hash comparison + metadata stripping) but uses standard HTTP semantics instead of a custom JSON endpoint.