### PR TITLE
fix: prevent server crashes from killing Kindle image delivery

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,16 +94,20 @@ async function getFileHash(filePath) {
 
   // --- Render lock to prevent overlapping cron ticks ---
   let renderInProgress = false;
+  let initInProgress = false;
   let browser = null;
 
   const safeRender = async () => {
-    if (!browser) {
-      console.log("Browser not ready, skipping render tick");
-      return;
-    }
     if (renderInProgress) {
       console.log("Render already in progress, skipping tick");
       return;
+    }
+    if (!browser) {
+      await initBrowser();
+      if (!browser) {
+        console.log("Browser not ready after init attempt, skipping render tick");
+        return;
+      }
     }
     renderInProgress = true;
     try {
@@ -234,9 +238,20 @@ async function getFileHash(filePath) {
   // --- Initialize browser and HA auth (non-blocking for HTTP) ---
   // If this fails, the HTTP server keeps serving the last good image.
   const initBrowser = async () => {
+    if (browser) {
+      return browser;
+    }
+    if (initInProgress) {
+      console.log("Browser init already in progress, skipping init attempt");
+      return null;
+    }
+
+    initInProgress = true;
+    let nextBrowser = null;
+    let page = null;
     try {
       console.log("Starting browser...");
-      browser = await puppeteer.launch({
+      nextBrowser = await puppeteer.launch({
         args: [
           "--disable-dev-shm-usage",
           "--no-sandbox",
@@ -249,7 +264,7 @@ async function getFileHash(filePath) {
       });
 
       console.log(`Visiting '${config.baseUrl}' to login...`);
-      let page = await browser.newPage();
+      page = await nextBrowser.newPage();
       await page.goto(config.baseUrl, {
         timeout: config.renderingTimeout
       });
@@ -275,8 +290,28 @@ async function getFileHash(filePath) {
       );
 
       await page.close();
+      page = null;
+
+      browser = nextBrowser;
+      browser.on("disconnected", () => {
+        browser = null;
+      });
+      return browser;
     } catch (err) {
       console.error("Browser/HA login failed, will retry on next render tick:", err);
+      if (page) {
+        await page.close().catch((closeErr) => {
+          console.error("Failed to close login page after browser init failure:", closeErr);
+        });
+      }
+      if (nextBrowser) {
+        await nextBrowser.close().catch((closeErr) => {
+          console.error("Failed to close browser after init failure:", closeErr);
+        });
+      }
+      return null;
+    } finally {
+      initInProgress = false;
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -87,51 +87,20 @@ async function getFileHash(filePath) {
     }
   }
 
-  console.log("Starting browser...");
-  let browser = await puppeteer.launch({
-    args: [
-      "--disable-dev-shm-usage",
-      "--no-sandbox",
-      `--lang=${config.language}`,
-      config.ignoreCertificateErrors && "--ignore-certificate-errors"
-    ].filter((x) => x),
-    defaultViewport: null,
-    timeout: config.browserLaunchTimeout,
-    headless: config.debug !== true
-  });
-
-  console.log(`Visiting '${config.baseUrl}' to login...`);
-  let page = await browser.newPage();
-  await page.goto(config.baseUrl, {
-    timeout: config.renderingTimeout
-  });
-
-  const hassTokens = {
-    hassUrl: config.baseUrl,
-    access_token: config.accessToken,
-    token_type: "Bearer"
-  };
-
-  console.log("Adding authentication entry to browser's local storage...");
-  await page.evaluate(
-    (hassTokens, selectedLanguage, selectedTheme) => {
-      localStorage.setItem("hassTokens", hassTokens);
-      localStorage.setItem("selectedLanguage", selectedLanguage);
-      if (selectedTheme) {
-        localStorage.setItem("selectedTheme", selectedTheme);
-      }
-    },
-    JSON.stringify(hassTokens),
-    JSON.stringify(config.language),
-    config.theme ? JSON.stringify(config.theme) : null
-  );
-
-  page.close();
+  // --- Start HTTP server IMMEDIATELY (before browser/render setup) ---
+  // This ensures the Kindle always gets the last good image,
+  // even if HA is temporarily unreachable during startup.
+  console.log("Starting HTTP server...");
 
   // --- Render lock to prevent overlapping cron ticks ---
   let renderInProgress = false;
+  let browser = null;
 
-  const safeRender = async (browser) => {
+  const safeRender = async () => {
+    if (!browser) {
+      console.log("Browser not ready, skipping render tick");
+      return;
+    }
     if (renderInProgress) {
       console.log("Render already in progress, skipping tick");
       return;
@@ -145,11 +114,6 @@ async function getFileHash(filePath) {
       renderInProgress = false;
     }
   };
-
-  // --- Start HTTP server IMMEDIATELY (before first render) ---
-  // This ensures the Kindle always gets the last good image,
-  // even if HA is temporarily unreachable during startup.
-  console.log("Starting HTTP server...");
 
   const requireAuth = config.httpAuthUser && config.httpAuthPassword;
   if (requireAuth) {
@@ -267,22 +231,76 @@ async function getFileHash(filePath) {
     console.log(`Server is running at ${port}`);
   });
 
+  // --- Initialize browser and HA auth (non-blocking for HTTP) ---
+  // If this fails, the HTTP server keeps serving the last good image.
+  const initBrowser = async () => {
+    try {
+      console.log("Starting browser...");
+      browser = await puppeteer.launch({
+        args: [
+          "--disable-dev-shm-usage",
+          "--no-sandbox",
+          `--lang=${config.language}`,
+          config.ignoreCertificateErrors && "--ignore-certificate-errors"
+        ].filter((x) => x),
+        defaultViewport: null,
+        timeout: config.browserLaunchTimeout,
+        headless: config.debug !== true
+      });
+
+      console.log(`Visiting '${config.baseUrl}' to login...`);
+      let page = await browser.newPage();
+      await page.goto(config.baseUrl, {
+        timeout: config.renderingTimeout
+      });
+
+      const hassTokens = {
+        hassUrl: config.baseUrl,
+        access_token: config.accessToken,
+        token_type: "Bearer"
+      };
+
+      console.log("Adding authentication entry to browser's local storage...");
+      await page.evaluate(
+        (hassTokens, selectedLanguage, selectedTheme) => {
+          localStorage.setItem("hassTokens", hassTokens);
+          localStorage.setItem("selectedLanguage", selectedLanguage);
+          if (selectedTheme) {
+            localStorage.setItem("selectedTheme", selectedTheme);
+          }
+        },
+        JSON.stringify(hassTokens),
+        JSON.stringify(config.language),
+        config.theme ? JSON.stringify(config.theme) : null
+      );
+
+      await page.close();
+    } catch (err) {
+      console.error("Browser/HA login failed, will retry on next render tick:", err);
+    }
+  };
+
   // --- Now start rendering (HTTP is already serving) ---
-  if (config.debug) {
-    console.log(
-      "Debug mode active, will only render once in non-headless model and keep page open"
-    );
-    safeRender(browser);
-  } else {
-    console.log("Starting first render...");
-    await safeRender(browser);
-    console.log("Starting rendering cronjob...");
-    new CronJob({
-      cronTime: config.cronJob,
-      onTick: () => safeRender(browser),
-      start: true
-    });
-  }
+  const startRendering = async () => {
+    await initBrowser();
+    if (config.debug) {
+      console.log(
+        "Debug mode active, will only render once in non-headless model and keep page open"
+      );
+      await safeRender();
+    } else {
+      console.log("Starting first render...");
+      await safeRender();
+      console.log("Starting rendering cronjob...");
+      new CronJob({
+        cronTime: config.cronJob,
+        onTick: () => safeRender(),
+        start: true
+      });
+    }
+  };
+
+  startRendering();
 })();
 
 async function renderAndConvertAsync(browser) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,19 @@ const crypto = require("crypto");
 // keep state of current battery level and whether the device is charging
 const batteryStore = {};
 
+/**
+ * Resolves the final output file path for a page, stripping duplicate extensions.
+ * e.g. OUTPUT_PATH=/output/cover.png + IMAGE_FORMAT=png → /output/cover.png
+ */
+function resolveOutputPath(pageConfig) {
+  let raw = pageConfig.outputPath;
+  const ext = `.${pageConfig.imageFormat}`;
+  if (raw.endsWith(ext)) {
+    raw = raw.slice(0, -ext.length);
+  }
+  return raw + ext;
+}
+
 // Helper function to calculate file hash
 async function getFileHash(filePath) {
   try {
@@ -127,7 +140,7 @@ async function getFileHash(filePath) {
     try {
       await renderAndConvertAsync(browser);
     } catch (err) {
-      console.error("Render job failed but server stays alive:", err.message || err);
+      console.error("Render job failed but server stays alive:", err);
     } finally {
       renderInProgress = false;
     }
@@ -190,7 +203,7 @@ async function getFileHash(filePath) {
       const pageIndex = pageNumber - 1;
       const configPage = config.pages[pageIndex];
 
-      const outputPathWithExtension = configPage.outputPath + "." + configPage.imageFormat;
+      const outputPathWithExtension = resolveOutputPath(configPage);
       const data = await fs.readFile(outputPathWithExtension);
       const stat = await fs.stat(outputPathWithExtension);
 
@@ -279,15 +292,7 @@ async function renderAndConvertAsync(browser) {
 
     const url = `${config.baseUrl}${pageConfig.screenShotUrl}`;
 
-    // Strip trailing extension from OUTPUT_PATH if it matches IMAGE_FORMAT
-    // to avoid double extensions like cover.png.png
-    let rawOutputPath = pageConfig.outputPath;
-    const extWithDot = `.${pageConfig.imageFormat}`;
-    if (rawOutputPath.endsWith(extWithDot)) {
-      rawOutputPath = rawOutputPath.slice(0, -extWithDot.length);
-      console.log(`Stripped duplicate extension from OUTPUT_PATH, using: ${rawOutputPath}`);
-    }
-    const outputPath = rawOutputPath + "." + pageConfig.imageFormat;
+    const outputPath = resolveOutputPath(pageConfig);
     await fsExtra.ensureDir(path.dirname(outputPath));
 
     const tempPath = outputPath + ".temp";
@@ -330,7 +335,7 @@ async function renderAndConvertAsync(browser) {
         await fsExtra.move(finalTempPath, outputPath, { overwrite: true });
       }
     } catch (err) {
-      console.error(`Convert/replace failed for ${url}, keeping previous image:`, err.message || err);
+      console.error(`Convert/replace failed for ${url}, keeping previous image:`, err);
     } finally {
       // Always clean up temp files
       await fsExtra.remove(tempPath).catch(() => {});

--- a/index.js
+++ b/index.js
@@ -115,21 +115,28 @@ async function getFileHash(filePath) {
 
   page.close();
 
-  if (config.debug) {
-    console.log(
-      "Debug mode active, will only render once in non-headless model and keep page open"
-    );
-    renderAndConvertAsync(browser);
-  } else {
-    console.log("Starting first render...");
-    await renderAndConvertAsync(browser);
-    console.log("Starting rendering cronjob...");
-    new CronJob({
-      cronTime: config.cronJob,
-      onTick: () => renderAndConvertAsync(browser),
-      start: true
-    });
-  }
+  // --- Render lock to prevent overlapping cron ticks ---
+  let renderInProgress = false;
+
+  const safeRender = async (browser) => {
+    if (renderInProgress) {
+      console.log("Render already in progress, skipping tick");
+      return;
+    }
+    renderInProgress = true;
+    try {
+      await renderAndConvertAsync(browser);
+    } catch (err) {
+      console.error("Render job failed but server stays alive:", err.message || err);
+    } finally {
+      renderInProgress = false;
+    }
+  };
+
+  // --- Start HTTP server IMMEDIATELY (before first render) ---
+  // This ensures the Kindle always gets the last good image,
+  // even if HA is temporarily unreachable during startup.
+  console.log("Starting HTTP server...");
 
   const requireAuth = config.httpAuthUser && config.httpAuthPassword;
   if (requireAuth) {
@@ -246,6 +253,23 @@ async function getFileHash(filePath) {
   httpServer.listen(port, () => {
     console.log(`Server is running at ${port}`);
   });
+
+  // --- Now start rendering (HTTP is already serving) ---
+  if (config.debug) {
+    console.log(
+      "Debug mode active, will only render once in non-headless model and keep page open"
+    );
+    safeRender(browser);
+  } else {
+    console.log("Starting first render...");
+    await safeRender(browser);
+    console.log("Starting rendering cronjob...");
+    new CronJob({
+      cronTime: config.cronJob,
+      onTick: () => safeRender(browser),
+      start: true
+    });
+  }
 })();
 
 async function renderAndConvertAsync(browser) {
@@ -255,7 +279,15 @@ async function renderAndConvertAsync(browser) {
 
     const url = `${config.baseUrl}${pageConfig.screenShotUrl}`;
 
-    const outputPath = pageConfig.outputPath + "." + pageConfig.imageFormat;
+    // Strip trailing extension from OUTPUT_PATH if it matches IMAGE_FORMAT
+    // to avoid double extensions like cover.png.png
+    let rawOutputPath = pageConfig.outputPath;
+    const extWithDot = `.${pageConfig.imageFormat}`;
+    if (rawOutputPath.endsWith(extWithDot)) {
+      rawOutputPath = rawOutputPath.slice(0, -extWithDot.length);
+      console.log(`Stripped duplicate extension from OUTPUT_PATH, using: ${rawOutputPath}`);
+    }
+    const outputPath = rawOutputPath + "." + pageConfig.imageFormat;
     await fsExtra.ensureDir(path.dirname(outputPath));
 
     const tempPath = outputPath + ".temp";
@@ -271,35 +303,40 @@ async function renderAndConvertAsync(browser) {
     console.log(`Converting rendered screenshot of ${url} to grayscale...`);
 
     const finalTempPath = outputPath + ".final.temp";
-    await convertImageToKindleCompatiblePngAsync(
-      pageConfig,
-      tempPath,
-      finalTempPath
-    );
+    try {
+      await convertImageToKindleCompatiblePngAsync(
+        pageConfig,
+        tempPath,
+        finalTempPath
+      );
 
-    // Compare with existing image — only update if changed
-    let hasChanged = true;
-    if (await fsExtra.pathExists(outputPath)) {
-      const newHash = await getFileHash(finalTempPath);
-      const existingHash = await getFileHash(outputPath);
+      // Compare with existing image — only update if changed
+      let hasChanged = true;
+      if (await fsExtra.pathExists(outputPath)) {
+        const newHash = await getFileHash(finalTempPath);
+        const existingHash = await getFileHash(outputPath);
 
-      if (newHash && existingHash && newHash === existingHash) {
-        hasChanged = false;
-        console.log(`Image unchanged for ${url}, skipping update`);
+        if (newHash && existingHash && newHash === existingHash) {
+          hasChanged = false;
+          console.log(`Image unchanged for ${url}, skipping update`);
+        } else {
+          console.log(`Image changed for ${url}, updating`);
+        }
       } else {
-        console.log(`Image changed for ${url}, updating`);
+        console.log(`First render for ${url}, creating image`);
       }
-    } else {
-      console.log(`First render for ${url}, creating image`);
+
+      if (hasChanged) {
+        await fsExtra.move(finalTempPath, outputPath, { overwrite: true });
+      }
+    } catch (err) {
+      console.error(`Convert/replace failed for ${url}, keeping previous image:`, err.message || err);
+    } finally {
+      // Always clean up temp files
+      await fsExtra.remove(tempPath).catch(() => {});
+      await fsExtra.remove(finalTempPath).catch(() => {});
     }
 
-    if (hasChanged) {
-      await fsExtra.move(finalTempPath, outputPath, { overwrite: true });
-    } else {
-      await fs.unlink(finalTempPath);
-    }
-
-    await fs.unlink(tempPath);
     console.log(`Finished ${url}`);
 
     if (

--- a/index.js
+++ b/index.js
@@ -335,7 +335,9 @@ async function getFileHash(filePath) {
     }
   };
 
-  startRendering();
+  startRendering().catch((err) => {
+    console.error("Rendering startup failed:", err);
+  });
 })();
 
 async function renderAndConvertAsync(browser) {


### PR DESCRIPTION
## Problem
The Kindle must be manually restarted ~once/day because it stops fetching images.

Root cause chain:
1. Server crashes when HA/Lovelace render times out (Puppeteer fails → convert on missing file → unhandled rejection)
2. During crash + restart, **HTTP server is unavailable** because it only starts after successful initial render
3. Kindle gets connection errors and its client loop stops polling
4. Even after server recovery, Kindle doesn't resume for ~20h

## P0 Fixes

### 1. HTTP server starts BEFORE first render
Previously the server only became available after a successful initial render. If HA was unreachable at startup, no HTTP endpoint existed at all. Now the server starts immediately and always serves the last good image — even during transient HA outages.

### 2. Render lock prevents overlapping cron ticks
Cron runs every minute but a render can take 40s+. Without a lock, parallel renders race on the same temp files. Added `renderInProgress` flag with skip-on-busy behavior.

### 3. Proper error isolation around all render operations
- Cron onTick uses `safeRender()` with try/catch/finally
- Convert failures no longer crash the process
- Temp files are always cleaned up in finally blocks

### 4. Strip duplicate file extension from OUTPUT_PATH
If `OUTPUT_PATH=/output/cover.png` and `IMAGE_FORMAT=png`, the result was `cover.png.png`. Now the duplicate is automatically stripped.

## Testing
- Syntax validated with `node -c index.js`
- No new dependencies added
- Fully backwards compatible

Fixes daily Kindle restart requirement caused by server instability.