### PR TITLE
chore: release 1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.0.16
+
+### Added
+
+* Add optional HTTP Basic Auth support for the rendered image endpoint
+* Add image change detection with ETag/HEAD support to reduce unnecessary Kindle image downloads
+* Add `HA_THEME` to explicitly select a Home Assistant theme
+* Add `.env` support for local configuration
+
+### Fixed
+
+* Validate required Home Assistant configuration earlier to avoid first-run `ERR_NAME_NOT_RESOLVED` failures
+* Keep the HTTP server available when browser initialization or rendering fails, and retry browser startup after failures
+* Update deprecated Home Assistant theme CSS variables for Home Assistant 2025.5+ compatibility
+
 ## 1.0.15
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Lovelace Kindle Screensaver
-version: 1.0.15
+version: 1.0.16
 slug: kindle-screensaver
 description: This tool can be used to display a Lovelace view of your Home Assistant instance on a jailbroken Kindle device. It regularly takes a screenshot which can be polled and used as a screensaver image of the online screensaver plugin.
 startup: application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-lovelace-kindle-screensaver",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "cron": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump add-on/package version from 1.0.15 to 1.0.16
- add 1.0.16 changelog entries for the changes merged since v1.0.15

## Verification

- `node --check` for repository JavaScript files
- parsed `package.json` and `package-lock.json` as JSON