### PR TITLE
Release 1.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.17
+
+### Added
+
+* Add Home Assistant add-on and Docker Compose configuration entries for optional HTTP Basic Auth
+* Add Vitest coverage for output path and image format handling
+
+### Fixed
+
+* Preserve configured `jpeg` and `bmp` output formats when writing converted temp files
+* Force GraphicsMagick to write the configured output format instead of inferring PNG from temp paths
+
 ## 1.0.16
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Lovelace Kindle Screensaver
-version: 1.0.16
+version: 1.0.17
 slug: kindle-screensaver
 description: This tool can be used to display a Lovelace view of your Home Assistant instance on a jailbroken Kindle device. It regularly takes a screenshot which can be polled and used as a screensaver image of the online screensaver plugin.
 startup: application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-lovelace-kindle-screensaver",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
         "cron": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package and Home Assistant add-on versions to 1.0.17
- add changelog notes for HTTP auth config entries, output format preservation, and Vitest coverage

## Tests
- npm test