### PR TITLE
Build Docker images for published releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: ci
 on:
   push:
     tags: [ 'v*.*.*' ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
 
 jobs:
   multi:


### PR DESCRIPTION
## Summary
- trigger Docker image builds when a GitHub release is published
- keep tag-push builds and add manual workflow dispatch for recovery runs

## Tests
- not run; workflow trigger-only change