### PR TITLE
Release 1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.18
+
+### Added
+
+* Add a render health endpoint and wire Docker/Home Assistant health checks to detect stale renders
+
+### Fixed
+
+* Recover from stale render locks by bounding render jobs and restarting Chromium after render timeouts
+* Add step-level render, screenshot, conversion, and file replacement timeouts with clearer error logging
+
 ## 1.0.17
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Lovelace Kindle Screensaver
-version: 1.0.17
+version: 1.0.18
 slug: kindle-screensaver
 description: This tool can be used to display a Lovelace view of your Home Assistant instance on a jailbroken Kindle device. It regularly takes a screenshot which can be polled and used as a screensaver image of the online screensaver plugin.
 startup: application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-lovelace-kindle-screensaver",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "MIT",
       "dependencies": {
         "cron": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package and Home Assistant add-on versions to 1.0.18
- add changelog entries for stale render lock recovery and render health checks

## Tests
- npm test
- node --check index.js && node --check config.js

## Note
- CHANGELOG.md keeps its existing CRLF line endings; plain `git diff --check` reports those added CRLF lines as trailing whitespace.