### PR TITLE
feat: add force refresh URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This tool regularly takes a screenshot of a specific page of your home assistant
 
 Using my [own Kindle 4 setup guide](https://github.com/sibbl/hass-lovelace-kindle-4) or the [online screensaver extension](https://www.mobileread.com/forums/showthread.php?t=236104) for any jailbroken Kindle, this image can be regularly polled from your device so you can use it as a weather station, a display for next public transport departures etc.
 
+It is further possible to pass `forceRefresh` in the request URL (e.g. `http://localhost:5000/?forceRefresh`) to trigger a full render of all pages before returning the response.
+Keep in mind that this will delay the response, so ensure the timeout on the client side is suitably set.
+
 ### Energy-efficient image updates
 
 The tool compares each new screenshot with the previous one and only updates the served image when changes are detected. This keeps the `Last-Modified` timestamp and `ETag` header stable, allowing e-ink clients to skip unnecessary downloads and screen refreshes.

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ class OperationTimeoutError extends Error {
   // --- Render lock to prevent overlapping cron ticks ---
   let renderInProgress = false;
   let renderStartedAt = null;
+  let currentRenderPromise = null;
   let activeRenderId = 0;
   let initInProgress = false;
   let browser = null;
@@ -122,9 +123,9 @@ class OperationTimeoutError extends Error {
       const lockAge = renderStartedAt ? Date.now() - renderStartedAt : 0;
       if (lockAge <= renderJobTimeout) {
         console.log(
-          `Render already in progress for ${lockAge}ms, skipping tick`
+          `Render already in progress for ${lockAge}ms, awaiting`
         );
-        return;
+        return currentRenderPromise;
       }
 
       console.error(
@@ -146,28 +147,33 @@ class OperationTimeoutError extends Error {
     const currentBrowser = browser;
     renderInProgress = true;
     renderStartedAt = Date.now();
-    let timedOut = false;
-    try {
-      await withTimeout(
-        renderAndConvertAsync(currentBrowser),
-        renderJobTimeout,
-        "render job",
-        () => {
-          timedOut = true;
+    currentRenderPromise = (async () => {
+      let timedOut = false;
+      try {
+        await withTimeout(
+          renderAndConvertAsync(currentBrowser),
+          renderJobTimeout,
+          "render job",
+          () => {
+            timedOut = true;
+          }
+        );
+        lastSuccessfulRenderAt = Date.now();
+      } catch (err) {
+        console.error("Render job failed but server stays alive:", err);
+        if (timedOut || err instanceof OperationTimeoutError) {
+          await closeCurrentBrowser("render timeout");
         }
-      );
-      lastSuccessfulRenderAt = Date.now();
-    } catch (err) {
-      console.error("Render job failed but server stays alive:", err);
-      if (timedOut || err instanceof OperationTimeoutError) {
-        await closeCurrentBrowser("render timeout");
+      } finally {
+        if (activeRenderId === renderId) {
+          currentRenderPromise = null;
+          renderInProgress = false;
+          renderStartedAt = null;
+        }
       }
-    } finally {
-      if (activeRenderId === renderId) {
-        renderInProgress = false;
-        renderStartedAt = null;
-      }
-    }
+    })();
+
+    return currentRenderPromise;
   };
 
   const requireAuth = config.httpAuthUser && config.httpAuthPassword;
@@ -234,6 +240,7 @@ class OperationTimeoutError extends Error {
     const isCharging = url.searchParams.get("isCharging");
     const pageNumber =
       pageNumberStr === "/" ? 1 : parseInt(pageNumberStr.substr(1));
+    const forceRefresh = url.searchParams.get("forceRefresh");
     if (
       isFinite(pageNumber) === false ||
       pageNumber > config.pages.length ||
@@ -243,6 +250,10 @@ class OperationTimeoutError extends Error {
       response.writeHead(400);
       response.end("Invalid request");
       return;
+    }
+    if (forceRefresh !== null) {
+      console.log("Force refresh requested, updating images...");
+      await safeRender();
     }
     try {
       // Log when the page was accessed


### PR DESCRIPTION
This adds the option of forcing a fresh render of all images before serving the request. It could potentially close #134.

I'm aware this is not the optimal path, as it renders all configured pages instead of just the requested one. I could try to adapt this to be on a per-page basis instead, if you like.
If you don't want this feature, feel free to just close the PR. I thought I'd share it in case anyone wants to use it.