### PR TITLE
Fix render timeout recovery

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const {
   resolveScreenshotTempPath
 } = require("./image-output");
 const {
+  throwIfAborted,
+  waitForAbortableTimeout,
   withTimeout
 } = require("./operation-timeout");
 const { RenderCoordinator } = require("./render-coordinator");
@@ -148,7 +150,8 @@ async function getFileHash(filePath) {
   const safeRender = () => {
     return renderCoordinator.run(
       "scheduled render job",
-      (currentBrowser) => renderAndConvertAsync(currentBrowser),
+      (currentBrowser, renderContext) =>
+        renderAndConvertAsync(currentBrowser, renderContext),
       { skipIfBusy: true }
     );
   };
@@ -158,7 +161,8 @@ async function getFileHash(filePath) {
       const pageIndex = pageNumber - 1;
       return renderCoordinator.run(
         `requested render for image ${pageNumber}`,
-        (currentBrowser) => renderPageAndConvertAsync(currentBrowser, pageIndex),
+        (currentBrowser, renderContext) =>
+          renderPageAndConvertAsync(currentBrowser, pageIndex, renderContext),
         {
           resetBrowserCache,
           updateLastSuccessfulRender: false
@@ -168,7 +172,8 @@ async function getFileHash(filePath) {
 
     return renderCoordinator.run(
       "requested render for all images",
-      (currentBrowser) => renderAndConvertAsync(currentBrowser),
+      (currentBrowser, renderContext) =>
+        renderAndConvertAsync(currentBrowser, renderContext),
       { resetBrowserCache }
     );
   };
@@ -490,13 +495,15 @@ async function getFileHash(filePath) {
   });
 })();
 
-async function renderAndConvertAsync(browser) {
+async function renderAndConvertAsync(browser, renderContext = {}) {
   let failedPages = 0;
 
   for (let pageIndex = 0; pageIndex < config.pages.length; pageIndex++) {
+    throwIfAborted(renderContext.signal, "render job");
     try {
-      await renderPageAndConvertAsync(browser, pageIndex);
+      await renderPageAndConvertAsync(browser, pageIndex, renderContext);
     } catch (err) {
+      throwIfAborted(renderContext.signal, "render job");
       failedPages++;
       console.error(`Render failed for page ${pageIndex + 1}:`, err);
     }
@@ -507,7 +514,7 @@ async function renderAndConvertAsync(browser) {
   }
 }
 
-async function renderPageAndConvertAsync(browser, pageIndex) {
+async function renderPageAndConvertAsync(browser, pageIndex, renderContext = {}) {
   const pageConfig = config.pages[pageIndex];
   const pageBatteryStore = batteryStore[pageIndex];
 
@@ -520,10 +527,18 @@ async function renderPageAndConvertAsync(browser, pageIndex) {
   );
 
   try {
+    throwIfAborted(renderContext.signal, "render page");
     await fsExtra.ensureDir(path.dirname(outputPath));
 
     console.log(`Rendering ${url} to image...`);
-    await renderUrlToImageAsync(browser, pageConfig, url, tempPath);
+    await renderUrlToImageAsync(
+      browser,
+      pageConfig,
+      url,
+      tempPath,
+      renderContext
+    );
+    throwIfAborted(renderContext.signal, "render page");
 
     if (!(await fsExtra.pathExists(tempPath))) {
       throw new Error(`Screenshot missing: ${tempPath}`);
@@ -540,6 +555,7 @@ async function renderPageAndConvertAsync(browser, pageIndex) {
       config.renderingTimeout,
       `convert ${url}`
     );
+    throwIfAborted(renderContext.signal, "render page");
 
     // Compare with existing image — only update if changed
     let hasChanged = true;
@@ -711,14 +727,22 @@ function writeJsonResponse(response, statusCode, payload) {
   response.end(body);
 }
 
-async function renderUrlToImageAsync(browser, pageConfig, url, path) {
+async function renderUrlToImageAsync(
+  browser,
+  pageConfig,
+  url,
+  path,
+  renderContext = {}
+) {
   let page;
   try {
+    throwIfAborted(renderContext.signal, `render ${url}`);
     page = await withTimeout(
       browser.newPage(),
       config.renderingTimeout,
       `open browser page for ${url}`
     );
+    throwIfAborted(renderContext.signal, `render ${url}`);
     await withTimeout(
       page.emulateMediaFeatures([
         {
@@ -729,6 +753,7 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
       config.renderingTimeout,
       `emulate media for ${url}`
     );
+    throwIfAborted(renderContext.signal, `render ${url}`);
 
     let size = {
       width: Number(pageConfig.renderingScreenSize.width),
@@ -747,18 +772,21 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
       config.renderingTimeout,
       `set viewport for ${url}`
     );
+    throwIfAborted(renderContext.signal, `render ${url}`);
     const startTime = new Date().valueOf();
     console.log(`Navigating to ${url}...`);
     await page.goto(url, {
       waitUntil: ["domcontentloaded", "load", "networkidle0"],
       timeout: config.renderingTimeout
     });
+    throwIfAborted(renderContext.signal, `render ${url}`);
 
     const navigateTimespan = new Date().valueOf() - startTime;
     console.log(`Waiting for home-assistant root on ${url}...`);
     await page.waitForSelector("home-assistant", {
       timeout: Math.max(config.renderingTimeout - navigateTimespan, 1000)
     });
+    throwIfAborted(renderContext.signal, `render ${url}`);
 
     await withTimeout(
       page.addStyleTag({
@@ -771,10 +799,16 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
       config.renderingTimeout,
       `add page style for ${url}`
     );
+    throwIfAborted(renderContext.signal, `render ${url}`);
 
     if (pageConfig.renderingDelay > 0) {
-      await page.waitForTimeout(pageConfig.renderingDelay);
+      await waitForAbortableTimeout(
+        pageConfig.renderingDelay,
+        renderContext.signal,
+        `rendering delay for ${url}`
+      );
     }
+    throwIfAborted(renderContext.signal, `render ${url}`);
     console.log(`Taking screenshot of ${url}...`);
     await withTimeout(
       page.screenshot({

--- a/operation-timeout.js
+++ b/operation-timeout.js
@@ -7,6 +7,14 @@ class OperationTimeoutError extends Error {
   }
 }
 
+class OperationAbortedError extends Error {
+  constructor(description) {
+    super(`${description} aborted`);
+    this.name = "OperationAbortedError";
+    this.description = description;
+  }
+}
+
 function withTimeout(promise, timeoutMs, description, onTimeout) {
   let timeoutId;
   const timeoutPromise = new Promise((resolve, reject) => {
@@ -23,7 +31,42 @@ function withTimeout(promise, timeoutMs, description, onTimeout) {
   });
 }
 
+function throwIfAborted(signal, description) {
+  if (signal && signal.aborted) {
+    throw new OperationAbortedError(description);
+  }
+}
+
+function waitForAbortableTimeout(timeoutMs, signal, description) {
+  throwIfAborted(signal, description);
+
+  return new Promise((resolve, reject) => {
+    let timeoutId;
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(new OperationAbortedError(description));
+    };
+
+    timeoutId = setTimeout(() => {
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      resolve();
+    }, timeoutMs);
+
+    if (signal) {
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) {
+        onAbort();
+      }
+    }
+  });
+}
+
 module.exports = {
+  OperationAbortedError,
   OperationTimeoutError,
+  throwIfAborted,
+  waitForAbortableTimeout,
   withTimeout
 };

--- a/render-coordinator.js
+++ b/render-coordinator.js
@@ -1,4 +1,5 @@
 const {
+  OperationAbortedError,
   OperationTimeoutError,
   withTimeout
 } = require("./operation-timeout");
@@ -9,13 +10,15 @@ class RenderCoordinator {
     ensureBrowser,
     closeBrowser,
     onSuccess,
-    logger = console
+    logger = console,
+    cleanupTimeout = 5000
   }) {
     this.renderJobTimeout = renderJobTimeout;
     this.ensureBrowser = ensureBrowser;
     this.closeBrowser = closeBrowser;
     this.onSuccess = onSuccess;
     this.logger = logger;
+    this.cleanupTimeout = cleanupTimeout;
     this.queue = Promise.resolve();
     this.pendingCount = 0;
     this.renderInProgress = false;
@@ -60,17 +63,23 @@ class RenderCoordinator {
     this.renderInProgress = true;
     this.renderStartedAt = Date.now();
     let timedOut = false;
+    const abortController = new AbortController();
+    let workPromise = null;
 
     try {
       const browser = await this.ensureBrowser({
         resetBrowserCache: options.resetBrowserCache === true
       });
+      workPromise = Promise.resolve().then(() => {
+        return work(browser, { signal: abortController.signal });
+      });
       await withTimeout(
-        work(browser),
+        workPromise,
         this.renderJobTimeout,
         label,
         () => {
           timedOut = true;
+          abortController.abort();
         }
       );
 
@@ -83,6 +92,7 @@ class RenderCoordinator {
       this.logger.error(`${label} failed but server stays alive:`, err);
       if (timedOut || err instanceof OperationTimeoutError) {
         await this.closeBrowser(`${label} timeout`);
+        await this.waitForTimedOutWork(label, workPromise);
       }
       return {
         status: "failed",
@@ -91,6 +101,37 @@ class RenderCoordinator {
     } finally {
       this.renderInProgress = false;
       this.renderStartedAt = null;
+    }
+  }
+
+  async waitForTimedOutWork(label, workPromise) {
+    if (!workPromise) {
+      return;
+    }
+
+    let cleanupTimedOut = false;
+    try {
+      await withTimeout(
+        workPromise.catch((err) => {
+          if (!(err instanceof OperationAbortedError)) {
+            this.logger.error(`${label} cleanup finished after error:`, err);
+          }
+        }),
+        this.cleanupTimeout,
+        `${label} cleanup`,
+        () => {
+          cleanupTimedOut = true;
+        }
+      );
+    } catch (err) {
+      if (cleanupTimedOut || err instanceof OperationTimeoutError) {
+        this.logger.error(
+          `${label} cleanup did not finish after ${this.cleanupTimeout}ms`
+        );
+        return;
+      }
+
+      this.logger.error(`${label} cleanup failed:`, err);
     }
   }
 }

--- a/render-coordinator.test.mjs
+++ b/render-coordinator.test.mjs
@@ -108,6 +108,7 @@ describe("render coordinator", () => {
     const closeBrowser = vi.fn();
     const coordinator = new RenderCoordinator({
       renderJobTimeout: 5,
+      cleanupTimeout: 5,
       ensureBrowser: vi.fn(async () => "browser"),
       closeBrowser,
       logger: { log: vi.fn(), error: vi.fn() }
@@ -121,5 +122,31 @@ describe("render coordinator", () => {
     expect(result.status).toBe("failed");
     expect(result.error).toContain("stuck render timed out");
     expect(closeBrowser).toHaveBeenCalledWith("stuck render timeout");
+  });
+
+  it("aborts timed-out work before releasing the render", async () => {
+    let aborted = false;
+    const coordinator = new RenderCoordinator({
+      renderJobTimeout: 5,
+      cleanupTimeout: 50,
+      ensureBrowser: vi.fn(async () => "browser"),
+      closeBrowser: vi.fn(),
+      logger: { log: vi.fn(), error: vi.fn() }
+    });
+
+    const result = await coordinator.run(
+      "slow render",
+      (browser, renderContext) => {
+        return new Promise((resolve) => {
+          renderContext.signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          });
+        });
+      }
+    );
+
+    expect(result.status).toBe("failed");
+    expect(aborted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- abort render work when the outer render job timeout fires
- close Chromium and wait briefly for the timed-out render promise to settle before releasing the render queue
- stop full-page render loops from continuing to later pages after an abort
- make rendering delays abortable and add coordinator coverage for timeout aborts

## Bug context
Observed in running sibbl/hass-lovelace-kindle-screensaver:latest containers:
- containers became unhealthy after scheduled renders got stuck opening Home Assistant Lovelace kiosk URLs
- logs showed page open timeouts followed by scheduled render job failed but server stays alive
- later scheduled renders were skipped as already queued or in progress, or kept failing until container restart

Expected behavior after this fix: after a browser/page open timeout, the render job aborts, browser state is reset, the render queue is released only after cleanup, and the next scheduled render can recover without a container restart.

## Testing
- npm test
- node --check index.js && node --check render-coordinator.js && node --check operation-timeout.js
- git diff --check