### PR TITLE
Release 1.1.0: support multiple Home Assistant instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
 
 ### Added
 
 * Support rendering pages from multiple Home Assistant instances with numbered `HA_BASE_URL_n`, `HA_ACCESS_TOKEN_n`, `HA_THEME_n`, and `LANGUAGE_n` variables
 * Isolate Home Assistant sessions in browser contexts while sharing one Chromium process
+
+### Fixed
+
+* Send battery webhook updates to the Home Assistant instance configured for each page
+* Avoid exposing additional environment variable values such as access tokens in Home Assistant Add-On logs
 
 ## 1.0.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* Support rendering pages from multiple Home Assistant instances with numbered `HA_BASE_URL_n`, `HA_ACCESS_TOKEN_n`, `HA_THEME_n`, and `LANGUAGE_n` variables
+* Isolate Home Assistant sessions in browser contexts while sharing one Chromium process
+
 ## 1.0.19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ Home Assistant related stuff:
 
 | Env Var                   | Sample value                          | Required | Array?\* | Description                                                                                                                                                                                          |
 |---------------------------|---------------------------------------| -------- | -------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `HA_BASE_URL`             | `https://your-hass-instance.com:8123` | yes      | no       | Base URL of your home assistant instance                                                                                                                                                             |
+| `HA_BASE_URL`             | `https://your-hass-instance.com:8123` | yes      | yes      | Base URL of your home assistant instance                                                                                                                                                             |
 | `HA_SCREENSHOT_URL`       | `/lovelace/screensaver?kiosk`         | yes      | yes      | Relative URL to take screenshot of (btw, the `?kiosk` parameter hides the nav bar using the [kiosk mode](https://github.com/NemesisRE/kiosk-mode) project)                                           |
-| `HA_ACCESS_TOKEN`         | `eyJ0...`                             | yes      | no       | Long-lived access token from Home Assistant, see [official docs](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token)                                                        |
+| `HA_ACCESS_TOKEN`         | `eyJ0...`                             | yes      | yes      | Long-lived access token from Home Assistant, see [official docs](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token)                                                        |
 | `HA_BATTERY_WEBHOOK`      | `set_kindle_battery_level`            | no       | yes      | Webhook definied in HA which receives `batteryLevel` (number between 0-100) and `isCharging` (boolean) as JSON                                                                                       |
-| `HA_THEME`                | `eink`                                | no       | no       | Name of the HA theme to use for rendering. Must be installed in your HA instance. When not set, HA's default theme is used.                                                                           |
+| `HA_THEME`                | `eink`                                | no       | yes      | Name of the HA theme to use for rendering. Must be installed in your HA instance. When not set, HA's default theme is used.                                                                           |
 | `HTTP_AUTH_USER`          | `admin`                               | no       | no       | Username for optional HTTP basic authentication on the image server. Requires `HTTP_AUTH_PASSWORD` to enable authentication.                                                                          |
 | `HTTP_AUTH_PASSWORD`      | `secret`                              | no       | no       | Password for optional HTTP basic authentication on the image server. Requires `HTTP_AUTH_USER` to enable authentication.                                                                              |
-| `LANGUAGE`                | `en`                                  | no       | no       | Language to set in browser and home assistant                                                                                                                                                        |
-| `PREFERS_COLOR_SCHEME`    | `light`                               | no       | no       | Enable browser dark mode, use `light` or `dark`.                                                                                                                                                     |
+| `LANGUAGE`                | `en`                                  | no       | yes      | Language to set in browser and home assistant                                                                                                                                                        |
+| `PREFERS_COLOR_SCHEME`    | `light`                               | no       | yes      | Enable browser dark mode, use `light` or `dark`.                                                                                                                                                     |
 | `CRON_JOB`                | `* * * * *`                           | no       | no       | How often to take screenshot                                                                                                                                                                         |
 | `RENDERING_TIMEOUT`       | `10000`                               | no       | no       | Timeout of render process, helpful if your HASS instance might be down                                                                                                                               |
 | `RENDERING_DELAY`         | `0`                                   | no       | yes      | how long to wait between navigating to the page and taking the screenshot, in milliseconds                                                                                                           |
@@ -79,27 +79,44 @@ Home Assistant related stuff:
 | `SCALING`                 | `1`                                   | no       | yes      | Scaling factor, e.g. `1.5` to zoom in or `0.75` to zoom out                                                                                                                                          |
 | `GRAYSCALE_DEPTH`         | `8`                                   | no       | yes      | Grayscale bit depth your kindle supports                                                                                                                                                             |
 | `COLOR_MODE`              | `GrayScale`                           | no       | yes      | ColorMode to use, ex: `GrayScale`, or `TrueColor`.                                                                                                                                                   |
-| `IMAGE_FORMAT`            | `png`                                 | no       | no       | Format for the generated images. Acceptable values are `png` or `jpeg`.                                                                                                                              |
+| `IMAGE_FORMAT`            | `png`                                 | no       | yes      | Format for the generated images. Acceptable values are `png` or `jpeg`.                                                                                                                              |
 | `DITHER`                  | `false`                               | no       | yes      | Apply a dither to the images.                                                                                                                                                                        |
-| `REMOVE_GAMMA`            | `true`                                | no       | no       | Remove gamma correction from image. Computer images are normally gamma corrected since monitors expect gamma corrected data, however some E-Ink displays expect images not to have gamma correction. |
-| SATURATION              | 2                                   | no       | no       | Saturation level multiplier, e.g. 2 doubles the saturation |
-| CONTRAST                | 2                                   | no       | no       | Contrast level multiplier, e.g. 2 doubles the contrast |
-| BLACK_LEVEL             | 30%                                 | no       | no       | Black point as percentage of MaxRGB, i.e. crushes blacks below specified level |
-| WHITE_LEVEL             | 90%                                 | no       | no       | White point as percentage of MaxRGB, i.e. crushes whites above specified level |
+| `REMOVE_GAMMA`            | `true`                                | no       | yes      | Remove gamma correction from image. Computer images are normally gamma corrected since monitors expect gamma corrected data, however some E-Ink displays expect images not to have gamma correction. |
+| `SATURATION`              | `2`                                   | no       | yes      | Saturation level multiplier, e.g. 2 doubles the saturation                                                                                                                                           |
+| `CONTRAST`                | `2`                                   | no       | yes      | Contrast level multiplier, e.g. 2 doubles the contrast                                                                                                                                               |
+| `BLACK_LEVEL`             | `30%`                                 | no       | yes      | Black point as percentage of MaxRGB, i.e. crushes blacks below specified level                                                                                                                       |
+| `WHITE_LEVEL`             | `90%`                                 | no       | yes      | White point as percentage of MaxRGB, i.e. crushes whites above specified level                                                                                                                       |
 
-**\* Array** means that you can set `HA_SCREENSHOT_URL_2`, `HA_SCREENSHOT_URL_3`, ... `HA_SCREENSHOT_URL_n` to render multiple pages within the same instance.
-If you use `HA_SCREENSHOT_URL_2`, you can also set `ROTATION_2=180`. If there is no `ROTATION_n` set, then `ROTATION` will be used as a fallback.
+**\* Array** means that you can append `_2`, `_3`, ... `_n` for a numbered output page. Numbered variables fall back to the unnumbered value when omitted. For example, `ROTATION_2=180` only changes the second image; without it, the second image uses `ROTATION`.
 You can access these additional images by making GET Requests `http://localhost:5000/2`, `http://localhost:5000/3` etc.
 
-To make us of the array feature in the Home Assistant Add-On, you may use `ADDITIONAL_ENV_VARS`. It expects a format like this to set any additional environment variable:
+### Multiple Home Assistant instances
+
+The same numbered variables can point each output page at a different Home Assistant instance. Existing single-instance configurations require no changes. This two-instance Docker Compose configuration renders the first image at `/` and the second at `/2`:
 
 ```yaml
+environment:
+  - HA_BASE_URL=https://first-home.example:8123
+  - HA_SCREENSHOT_URL=/lovelace/kindle?kiosk
+  - HA_ACCESS_TOKEN=first-long-lived-token
+  - HA_BASE_URL_2=https://second-home.example:8123
+  - HA_SCREENSHOT_URL_2=/lovelace/kindle?kiosk
+  - HA_ACCESS_TOKEN_2=second-long-lived-token
+```
+
+Add `_3`, `_4`, and so on for more instances. The numbered `HA_SCREENSHOT_URL` values must be contiguous. You can also override `HA_THEME_n`, `LANGUAGE_n`, the battery webhook, and any other page option marked as an array. Omit a numbered setting when that page should inherit the first page's value—for example, several dashboards from the same Home Assistant instance only need additional `HA_SCREENSHOT_URL_n` values.
+
+All pages share one Chromium process. Each distinct Home Assistant configuration uses an isolated browser context within that process, keeping tokens and browser storage separate without running another container or browser.
+
+To use numbered variables in the Home Assistant Add-On, add them under `ADDITIONAL_ENV_VARS`:
+
+```yaml
+- name: "HA_BASE_URL_2"
+  value: "https://second-home.example:8123"
 - name: "HA_SCREENSHOT_URL_2"
-  value: "/lovelace/second-page"
-- name: "ROTATION_2"
-  value: "180"
-- name: "HA_SCREENSHOT_URL_3"
-  value: "/lovelace/third-page"
+  value: "/lovelace/kindle?kiosk"
+- name: "HA_ACCESS_TOKEN_2"
+  value: "second-long-lived-token"
 ```
 
 To avoid problems, please ensure that the name only contains upper case letters, numbers and underscores. The value field must be a string, so it's better to always put your value (especially numbers) into a `"string"` .
@@ -146,7 +163,7 @@ Modify the following lines in the HASS Lovelace Kindle 4 extension's [`script.sh
 
 Some advanced variables for local usage which shouldn't be necessary when using Docker:
 
-- `OUTPUT_PATH=./output` (destination of rendered image, without extension. `OUTPUT_2`, `OUTPUT_3`, ... is also supported)
+- `OUTPUT_PATH=./output` (destination of rendered image, without extension. `OUTPUT_PATH_2`, `OUTPUT_PATH_3`, ... is also supported)
 - `PORT=5000` (port of server, which returns the last image)
 - `USE_IMAGE_MAGICK=false` (use ImageMagick instead of GraphicsMagick)
 - `UNSAFE_IGNORE_CERTIFICATE_ERRORS=true` (ignore certificate errors of e.g. self-signed certificates at your own risk)

--- a/config.js
+++ b/config.js
@@ -28,8 +28,13 @@ function getPagesConfig() {
     const suffix = i === 1 ? "" : `_${i}`;
     const screenShotUrl = process.env[`HA_SCREENSHOT_URL${suffix}`];
     if (!screenShotUrl) return pages;
+    const theme = getEnvironmentVariable("HA_THEME", suffix);
     pages.push({
+      baseUrl: getEnvironmentVariable("HA_BASE_URL", suffix),
+      accessToken: getEnvironmentVariable("HA_ACCESS_TOKEN", suffix),
       screenShotUrl,
+      language: getEnvironmentVariable("LANGUAGE", suffix) || "en",
+      theme: theme ? { theme } : null,
       imageFormat: getEnvironmentVariable("IMAGE_FORMAT", suffix) || "png",
       outputPath: getEnvironmentVariable(
         "OUTPUT_PATH",
@@ -60,6 +65,8 @@ function getPagesConfig() {
 }
 
 module.exports = {
+  // Keep these top-level values for backwards compatibility. Rendering uses the
+  // resolved values on each page, which may override them with a numbered env var.
   baseUrl: process.env.HA_BASE_URL,
   accessToken: process.env.HA_ACCESS_TOKEN,
   cronJob: process.env.CRON_JOB || "* * * * *",

--- a/config.test.mjs
+++ b/config.test.mjs
@@ -1,19 +1,42 @@
 import { createRequire } from "module";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
-const originalBrowserCacheTtl = process.env.BROWSER_CACHE_TTL_SECONDS;
+const managedEnvironmentVariables = [
+  "BROWSER_CACHE_TTL_SECONDS",
+  "HA_BASE_URL",
+  "HA_BASE_URL_2",
+  "HA_SCREENSHOT_URL",
+  "HA_SCREENSHOT_URL_2",
+  "HA_ACCESS_TOKEN",
+  "HA_ACCESS_TOKEN_2",
+  "HA_THEME",
+  "HA_THEME_2",
+  "LANGUAGE",
+  "LANGUAGE_2"
+];
+const originalEnvironment = Object.fromEntries(
+  managedEnvironmentVariables.map((key) => [key, process.env[key]])
+);
 
 function loadConfig() {
   delete require.cache[require.resolve("./config.js")];
   return require("./config.js");
 }
 
+beforeEach(() => {
+  for (const key of managedEnvironmentVariables) {
+    delete process.env[key];
+  }
+});
+
 afterEach(() => {
-  if (originalBrowserCacheTtl === undefined) {
-    delete process.env.BROWSER_CACHE_TTL_SECONDS;
-  } else {
-    process.env.BROWSER_CACHE_TTL_SECONDS = originalBrowserCacheTtl;
+  for (const key of managedEnvironmentVariables) {
+    if (originalEnvironment[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalEnvironment[key];
+    }
   }
   delete require.cache[require.resolve("./config.js")];
 });
@@ -35,5 +58,64 @@ describe("config", () => {
 
     expect(config.browserCacheTtlSeconds).toBe(0);
     expect(config.browserCacheTtl).toBe(0);
+  });
+
+  it("keeps legacy Home Assistant configuration on the first page", () => {
+    process.env.HA_BASE_URL = "https://home.example.test";
+    process.env.HA_SCREENSHOT_URL = "/lovelace/kindle";
+    process.env.HA_ACCESS_TOKEN = "legacy-token";
+    process.env.HA_THEME = "eink";
+    process.env.LANGUAGE = "de";
+
+    const config = loadConfig();
+
+    expect(config.baseUrl).toBe("https://home.example.test");
+    expect(config.accessToken).toBe("legacy-token");
+    expect(config.pages).toHaveLength(1);
+    expect(config.pages[0]).toMatchObject({
+      baseUrl: "https://home.example.test",
+      screenShotUrl: "/lovelace/kindle",
+      accessToken: "legacy-token",
+      language: "de",
+      theme: { theme: "eink" }
+    });
+  });
+
+  it("inherits legacy values when additional pages use the same instance", () => {
+    process.env.HA_BASE_URL = "https://home.example.test";
+    process.env.HA_SCREENSHOT_URL = "/lovelace/first";
+    process.env.HA_SCREENSHOT_URL_2 = "/lovelace/second";
+    process.env.HA_ACCESS_TOKEN = "shared-token";
+
+    const config = loadConfig();
+
+    expect(config.pages).toHaveLength(2);
+    expect(config.pages[1]).toMatchObject({
+      baseUrl: "https://home.example.test",
+      accessToken: "shared-token",
+      language: "en"
+    });
+  });
+
+  it("allows additional pages to override their Home Assistant instance", () => {
+    process.env.HA_BASE_URL = "https://first.example.test";
+    process.env.HA_SCREENSHOT_URL = "/lovelace/first";
+    process.env.HA_ACCESS_TOKEN = "first-token";
+    process.env.HA_BASE_URL_2 = "https://second.example.test";
+    process.env.HA_SCREENSHOT_URL_2 = "/lovelace/second";
+    process.env.HA_ACCESS_TOKEN_2 = "second-token";
+    process.env.HA_THEME_2 = "night";
+    process.env.LANGUAGE_2 = "fr";
+
+    const config = loadConfig();
+
+    expect(config.pages).toHaveLength(2);
+    expect(config.pages[1]).toMatchObject({
+      baseUrl: "https://second.example.test",
+      screenShotUrl: "/lovelace/second",
+      accessToken: "second-token",
+      language: "fr",
+      theme: { theme: "night" }
+    });
   });
 });

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Lovelace Kindle Screensaver
-version: 1.0.19
+version: 1.1.0
 slug: kindle-screensaver
 description: This tool can be used to display a Lovelace view of your Home Assistant instance on a jailbroken Kindle device. It regularly takes a screenshot which can be polled and used as a screensaver image of the online screensaver plugin.
 startup: application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - HA_BASE_URL=https://your-path-to-home-assistant:8123
       - HA_SCREENSHOT_URL=/lovelace?kiosk
       - HA_ACCESS_TOKEN=eyJ0...
+      # To render another Home Assistant instance in the same Chromium process,
+      # uncomment and configure the three numbered variables below. Its image is at /2.
+      # - HA_BASE_URL_2=https://your-second-home-assistant:8123
+      # - HA_SCREENSHOT_URL_2=/lovelace?kiosk
+      # - HA_ACCESS_TOKEN_2=eyJ0...
       # Uncomment both HTTP_AUTH_* variables to require basic auth for the image endpoint.
       # - HTTP_AUTH_USER=admin
       # - HTTP_AUTH_PASSWORD=secret

--- a/home-assistant-auth.js
+++ b/home-assistant-auth.js
@@ -1,0 +1,105 @@
+const contextsByBrowser = new WeakMap();
+
+function getInstanceKey(pageConfig) {
+  return JSON.stringify([
+    pageConfig.baseUrl,
+    pageConfig.accessToken,
+    pageConfig.language,
+    pageConfig.theme
+  ]);
+}
+
+async function createAuthenticatedContext(
+  browser,
+  pageConfig,
+  renderingTimeout,
+  logger
+) {
+  const browserContext = await browser.createIncognitoBrowserContext();
+  let page = null;
+  let authenticationFailed = false;
+
+  try {
+    logger.log(`Visiting '${pageConfig.baseUrl}' to login...`);
+    page = await browserContext.newPage();
+    await page.goto(pageConfig.baseUrl, {
+      timeout: renderingTimeout
+    });
+
+    const hassTokens = {
+      hassUrl: pageConfig.baseUrl,
+      access_token: pageConfig.accessToken,
+      token_type: "Bearer"
+    };
+
+    logger.log("Adding authentication entry to browser's local storage...");
+    await page.evaluate(
+      (tokens, selectedLanguage, selectedTheme) => {
+        localStorage.setItem("hassTokens", tokens);
+        localStorage.setItem("selectedLanguage", selectedLanguage);
+        if (selectedTheme) {
+          localStorage.setItem("selectedTheme", selectedTheme);
+        }
+      },
+      JSON.stringify(hassTokens),
+      JSON.stringify(pageConfig.language),
+      pageConfig.theme ? JSON.stringify(pageConfig.theme) : null
+    );
+
+    return browserContext;
+  } catch (err) {
+    authenticationFailed = true;
+    throw err;
+  } finally {
+    if (page) {
+      await page.close().catch((err) => {
+        logger.error(
+          "Failed to close login page after Home Assistant authentication:",
+          err
+        );
+      });
+    }
+    if (authenticationFailed) {
+      await browserContext.close().catch(() => {});
+    }
+  }
+}
+
+async function getAuthenticatedContext(
+  browser,
+  pageConfig,
+  renderingTimeout,
+  logger = console
+) {
+  let browserContexts = contextsByBrowser.get(browser);
+  if (!browserContexts) {
+    browserContexts = new Map();
+    contextsByBrowser.set(browser, browserContexts);
+  }
+
+  const instanceKey = getInstanceKey(pageConfig);
+  let contextPromise = browserContexts.get(instanceKey);
+
+  if (!contextPromise) {
+    contextPromise = createAuthenticatedContext(
+      browser,
+      pageConfig,
+      renderingTimeout,
+      logger
+    );
+    browserContexts.set(instanceKey, contextPromise);
+  }
+
+  try {
+    return await contextPromise;
+  } catch (err) {
+    if (browserContexts.get(instanceKey) === contextPromise) {
+      browserContexts.delete(instanceKey);
+    }
+    throw err;
+  }
+}
+
+module.exports = {
+  getAuthenticatedContext
+};

--- a/home-assistant-auth.test.mjs
+++ b/home-assistant-auth.test.mjs
@@ -1,0 +1,143 @@
+import { createRequire } from "module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { getAuthenticatedContext } = require("./home-assistant-auth.js");
+
+function createPageConfig(overrides = {}) {
+  return {
+    baseUrl: "https://home.example.test",
+    accessToken: "token",
+    language: "en",
+    theme: null,
+    ...overrides
+  };
+}
+
+function createBrowserContext() {
+  const page = {
+    goto: vi.fn(async () => {}),
+    evaluate: vi.fn(async () => {}),
+    close: vi.fn(async () => {})
+  };
+  const browserContext = {
+    newPage: vi.fn(async () => page),
+    close: vi.fn(async () => {})
+  };
+
+  return { browserContext, page };
+}
+
+function createLogger() {
+  return { log: vi.fn(), error: vi.fn() };
+}
+
+describe("Home Assistant browser authentication", () => {
+  it("adds instance-specific authentication to an isolated browser context", async () => {
+    const { browserContext, page } = createBrowserContext();
+    const browser = {
+      createIncognitoBrowserContext: vi.fn(async () => browserContext)
+    };
+    const pageConfig = createPageConfig({
+      accessToken: "secret-token",
+      language: "de",
+      theme: { theme: "eink" }
+    });
+
+    await expect(
+      getAuthenticatedContext(browser, pageConfig, 1234, createLogger())
+    ).resolves.toBe(browserContext);
+
+    expect(page.goto).toHaveBeenCalledWith("https://home.example.test", {
+      timeout: 1234
+    });
+    expect(page.evaluate.mock.calls[0].slice(1)).toEqual([
+      JSON.stringify({
+        hassUrl: "https://home.example.test",
+        access_token: "secret-token",
+        token_type: "Bearer"
+      }),
+      JSON.stringify("de"),
+      JSON.stringify({ theme: "eink" })
+    ]);
+    expect(page.close).toHaveBeenCalledOnce();
+  });
+
+  it("reuses one context for pages with the same instance settings", async () => {
+    const { browserContext } = createBrowserContext();
+    const browser = {
+      createIncognitoBrowserContext: vi.fn(async () => browserContext)
+    };
+    const logger = createLogger();
+
+    const firstContext = await getAuthenticatedContext(
+      browser,
+      createPageConfig(),
+      1000,
+      logger
+    );
+    const secondContext = await getAuthenticatedContext(
+      browser,
+      createPageConfig(),
+      1000,
+      logger
+    );
+
+    expect(firstContext).toBe(secondContext);
+    expect(browser.createIncognitoBrowserContext).toHaveBeenCalledOnce();
+  });
+
+  it("isolates distinct credentials even when the base URL is the same", async () => {
+    const first = createBrowserContext();
+    const second = createBrowserContext();
+    const browser = {
+      createIncognitoBrowserContext: vi
+        .fn()
+        .mockResolvedValueOnce(first.browserContext)
+        .mockResolvedValueOnce(second.browserContext)
+    };
+    const logger = createLogger();
+
+    const firstContext = await getAuthenticatedContext(
+      browser,
+      createPageConfig({ accessToken: "first-token" }),
+      1000,
+      logger
+    );
+    const secondContext = await getAuthenticatedContext(
+      browser,
+      createPageConfig({ accessToken: "second-token" }),
+      1000,
+      logger
+    );
+
+    expect(firstContext).toBe(first.browserContext);
+    expect(secondContext).toBe(second.browserContext);
+    expect(browser.createIncognitoBrowserContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("discards failed authentication contexts so the next render can retry", async () => {
+    const failed = createBrowserContext();
+    failed.page.goto.mockRejectedValueOnce(new Error("instance unavailable"));
+    const recovered = createBrowserContext();
+    const browser = {
+      createIncognitoBrowserContext: vi
+        .fn()
+        .mockResolvedValueOnce(failed.browserContext)
+        .mockResolvedValueOnce(recovered.browserContext)
+    };
+    const logger = createLogger();
+    const pageConfig = createPageConfig();
+
+    await expect(
+      getAuthenticatedContext(browser, pageConfig, 1000, logger)
+    ).rejects.toThrow("instance unavailable");
+    await expect(
+      getAuthenticatedContext(browser, pageConfig, 1000, logger)
+    ).resolves.toBe(recovered.browserContext);
+
+    expect(failed.page.close).toHaveBeenCalledOnce();
+    expect(failed.browserContext.close).toHaveBeenCalledOnce();
+    expect(browser.createIncognitoBrowserContext).toHaveBeenCalledTimes(2);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const {
   withTimeout
 } = require("./operation-timeout");
 const { RenderCoordinator } = require("./render-coordinator");
+const { getAuthenticatedContext } = require("./home-assistant-auth");
 
 // keep state of current battery level and whether the device is charging
 const batteryStore = {};
@@ -39,48 +40,58 @@ async function getFileHash(filePath) {
     return console.error("Please check your configuration");
   }
   
-  // Validate HA_BASE_URL is not the default placeholder
-  if (!config.baseUrl || config.baseUrl.trim() === '') {
-    console.error("ERROR: HA_BASE_URL is not configured.");
-    console.error("Please set HA_BASE_URL to your Home Assistant instance URL.");
-    return console.error("Example: https://homeassistant.local:8123 or http://192.168.1.100:8123");
-  }
-  
-  // Check for common placeholder values
   const placeholderPatterns = [
     'your-path-to-home-assistant',
     'your-hass-instance',
     'your-home-assistant',
     'example.com'
   ];
-  
-  const baseUrlLower = config.baseUrl.toLowerCase();
-  for (const pattern of placeholderPatterns) {
-    if (baseUrlLower.includes(pattern)) {
-      console.error(`ERROR: HA_BASE_URL contains placeholder text: "${config.baseUrl}"`);
-      console.error("Please update HA_BASE_URL to your actual Home Assistant instance URL.");
-      console.error("Examples:");
-      console.error("  - https://homeassistant.local:8123");
-      console.error("  - http://192.168.1.100:8123");
-      return console.error("  - https://my-home.duckdns.org:8123");
+
+  for (const [pageIndex, pageConfig] of config.pages.entries()) {
+    const suffix = pageIndex === 0 ? "" : `_${pageIndex + 1}`;
+    const baseUrlVariable = `HA_BASE_URL${suffix}`;
+    const accessTokenVariable = `HA_ACCESS_TOKEN${suffix}`;
+
+    if (!pageConfig.baseUrl || pageConfig.baseUrl.trim() === '') {
+      console.error(`ERROR: ${baseUrlVariable} is not configured.`);
+      console.error(
+        `Please set ${baseUrlVariable} to the Home Assistant instance URL for page ${pageIndex + 1}.`
+      );
+      return console.error(
+        "Example: https://homeassistant.local:8123 or http://192.168.1.100:8123"
+      );
     }
-  }
-  
-  // Validate HA_ACCESS_TOKEN is provided
-  if (!config.accessToken || config.accessToken.trim() === '') {
-    console.error("ERROR: HA_ACCESS_TOKEN is not configured.");
-    console.error("Please create a long-lived access token in Home Assistant:");
-    console.error("  1. Go to your Home Assistant profile");
-    console.error("  2. Scroll down to 'Long-Lived Access Tokens'");
-    console.error("  3. Click 'Create Token'");
-    return console.error("  4. Copy the token and set it as HA_ACCESS_TOKEN");
-  }
-  
-  for (const i in config.pages) {
-    const pageConfig = config.pages[i];
+
+    const baseUrlLower = pageConfig.baseUrl.toLowerCase();
+    for (const pattern of placeholderPatterns) {
+      if (baseUrlLower.includes(pattern)) {
+        console.error(
+          `ERROR: ${baseUrlVariable} contains placeholder text: "${pageConfig.baseUrl}"`
+        );
+        console.error(
+          `Please update ${baseUrlVariable} to the actual Home Assistant instance URL.`
+        );
+        console.error("Examples:");
+        console.error("  - https://homeassistant.local:8123");
+        console.error("  - http://192.168.1.100:8123");
+        return console.error("  - https://my-home.duckdns.org:8123");
+      }
+    }
+
+    if (!pageConfig.accessToken || pageConfig.accessToken.trim() === '') {
+      console.error(`ERROR: ${accessTokenVariable} is not configured.`);
+      console.error("Please create a long-lived access token in Home Assistant:");
+      console.error("  1. Go to your Home Assistant profile");
+      console.error("  2. Scroll down to 'Long-Lived Access Tokens'");
+      console.error("  3. Click 'Create Token'");
+      return console.error(
+        `  4. Copy the token and set it as ${accessTokenVariable}`
+      );
+    }
+
     if (pageConfig.rotation % 90 > 0) {
       return console.error(
-        `Invalid rotation value for entry ${i + 1}: ${pageConfig.rotation}`
+        `Invalid rotation value for entry ${pageIndex + 1}: ${pageConfig.rotation}`
       );
     }
   }
@@ -381,7 +392,7 @@ async function getFileHash(filePath) {
     console.log(`Server is running at ${port}`);
   });
 
-  // --- Initialize browser and HA auth (non-blocking for HTTP) ---
+  // --- Initialize browser (non-blocking for HTTP) ---
   // If this fails, the HTTP server keeps serving the last good image.
   const initBrowser = async () => {
     if (browser) {
@@ -394,7 +405,6 @@ async function getFileHash(filePath) {
 
     initInProgress = true;
     let nextBrowser = null;
-    let page = null;
     try {
       console.log("Starting browser...");
       nextBrowser = await puppeteer.launch({
@@ -409,35 +419,6 @@ async function getFileHash(filePath) {
         headless: config.debug !== true
       });
 
-      console.log(`Visiting '${config.baseUrl}' to login...`);
-      page = await nextBrowser.newPage();
-      await page.goto(config.baseUrl, {
-        timeout: config.renderingTimeout
-      });
-
-      const hassTokens = {
-        hassUrl: config.baseUrl,
-        access_token: config.accessToken,
-        token_type: "Bearer"
-      };
-
-      console.log("Adding authentication entry to browser's local storage...");
-      await page.evaluate(
-        (hassTokens, selectedLanguage, selectedTheme) => {
-          localStorage.setItem("hassTokens", hassTokens);
-          localStorage.setItem("selectedLanguage", selectedLanguage);
-          if (selectedTheme) {
-            localStorage.setItem("selectedTheme", selectedTheme);
-          }
-        },
-        JSON.stringify(hassTokens),
-        JSON.stringify(config.language),
-        config.theme ? JSON.stringify(config.theme) : null
-      );
-
-      await page.close();
-      page = null;
-
       browser = nextBrowser;
       browserStartedAt = Date.now();
       browser.on("disconnected", () => {
@@ -448,12 +429,7 @@ async function getFileHash(filePath) {
       });
       return browser;
     } catch (err) {
-      console.error("Browser/HA login failed, will retry on next render tick:", err);
-      if (page) {
-        await page.close().catch((closeErr) => {
-          console.error("Failed to close login page after browser init failure:", closeErr);
-        });
-      }
+      console.error("Browser startup failed, will retry on next render tick:", err);
       if (nextBrowser) {
         await nextBrowser.close().catch((closeErr) => {
           console.error("Failed to close browser after init failure:", closeErr);
@@ -511,7 +487,7 @@ async function renderPageAndConvertAsync(browser, pageIndex) {
   const pageConfig = config.pages[pageIndex];
   const pageBatteryStore = batteryStore[pageIndex];
 
-  const url = `${config.baseUrl}${pageConfig.screenShotUrl}`;
+  const url = `${pageConfig.baseUrl}${pageConfig.screenShotUrl}`;
   const outputPath = resolveOutputPath(pageConfig);
   const tempPath = resolveScreenshotTempPath(outputPath);
   const finalTempPath = resolveFinalTempPath(
@@ -575,6 +551,7 @@ async function renderPageAndConvertAsync(browser, pageIndex) {
       sendBatteryLevelToHomeAssistant(
         pageIndex,
         pageBatteryStore,
+        pageConfig.baseUrl,
         pageConfig.batteryWebHook
       );
     }
@@ -590,6 +567,7 @@ async function renderPageAndConvertAsync(browser, pageIndex) {
 function sendBatteryLevelToHomeAssistant(
   pageIndex,
   batteryStore,
+  baseUrl,
   batteryWebHook
 ) {
   const batteryStatus = JSON.stringify(batteryStore);
@@ -601,7 +579,7 @@ function sendBatteryLevelToHomeAssistant(
     },
     rejectUnauthorized: !config.ignoreCertificateErrors
   };
-  const url = `${config.baseUrl}/api/webhook/${batteryWebHook}`;
+  const url = `${baseUrl}/api/webhook/${batteryWebHook}`;
   const httpLib = url.toLowerCase().startsWith("https") ? https : http;
   const req = httpLib.request(url, options, (res) => {
     if (res.statusCode !== 200) {
@@ -714,8 +692,13 @@ function writeJsonResponse(response, statusCode, payload) {
 async function renderUrlToImageAsync(browser, pageConfig, url, path) {
   let page;
   try {
+    const browserContext = await getAuthenticatedContext(
+      browser,
+      pageConfig,
+      config.renderingTimeout
+    );
     page = await withTimeout(
-      browser.newPage(),
+      browserContext.newPage(),
       config.renderingTimeout,
       `open browser page for ${url}`
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.19",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-lovelace-kindle-screensaver",
-      "version": "1.0.19",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "cron": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.0.19",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,7 @@ bashio::log.info "Loading additional environment variables..."
 for var in $(bashio::config 'ADDITIONAL_ENV_VARS|keys'); do
     name=$(bashio::config "ADDITIONAL_ENV_VARS[${var}].name")
     value=$(bashio::config "ADDITIONAL_ENV_VARS[${var}].value")
-    bashio::log.info "Setting ${name} to ${value}"
+    bashio::log.info "Setting additional environment variable ${name}"
     export "${name}=${value}"
 done
 


### PR DESCRIPTION
## Summary

- allow each numbered output page to override `HA_BASE_URL`, `HA_ACCESS_TOKEN`, `HA_THEME`, and `LANGUAGE` while retaining the existing unnumbered fallback behavior
- keep one shared Chromium process and isolate distinct Home Assistant sessions in browser contexts so tokens and local storage cannot collide
- route screenshots and battery webhooks through each page's configured Home Assistant instance
- document Docker Compose and Home Assistant Add-On setup for two or more instances
- avoid logging `ADDITIONAL_ENV_VARS` values, which may contain additional access tokens
- prepare release `1.1.0` in `package.json`, `package-lock.json`, the Home Assistant Add-On manifest, and the changelog

## Backwards compatibility

Existing single-instance configurations do not need any changes. Existing multi-page configurations also continue to inherit the unnumbered Home Assistant URL and access token unless numbered overrides are supplied.

The Home Assistant Add-On continues to use its existing unlimited `ADDITIONAL_ENV_VARS` list for `_2`, `_3`, and later settings instead of adding a fixed number of instance fields to `config.yaml`.

## Security note

The add-on still logs the name of each additional environment variable, but no longer logs its value. This prevents long-lived Home Assistant tokens such as `HA_ACCESS_TOKEN_2` from being exposed in add-on logs.

## Testing

- `npm test` — 23 tests passed
- `node --check index.js`
- `node --check config.js`
- `node --check home-assistant-auth.js`
- version consistency checks for `1.1.0`
- `git diff --check`
- `docker compose config --quiet`

A live Home Assistant/Chromium integration run was not available in the local checkout because Puppeteer's Chromium binary is not installed; authentication/context behavior is covered by unit tests.
