### PR TITLE
Support numbered HTTP auth credentials and prepare 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.0
+
+### Added
+
+* Support page-specific HTTP Basic Auth credentials with numbered `HTTP_AUTH_USER_n` and `HTTP_AUTH_PASSWORD_n` variables
+
+### Fixed
+
+* Pass configured HTTP Basic Auth credentials into the Home Assistant Add-On runtime
+
 ## 1.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Home Assistant related stuff:
 | `HA_ACCESS_TOKEN`         | `eyJ0...`                             | yes      | yes      | Long-lived access token from Home Assistant, see [official docs](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token)                                                        |
 | `HA_BATTERY_WEBHOOK`      | `set_kindle_battery_level`            | no       | yes      | Webhook definied in HA which receives `batteryLevel` (number between 0-100) and `isCharging` (boolean) as JSON                                                                                       |
 | `HA_THEME`                | `eink`                                | no       | yes      | Name of the HA theme to use for rendering. Must be installed in your HA instance. When not set, HA's default theme is used.                                                                           |
-| `HTTP_AUTH_USER`          | `admin`                               | no       | no       | Username for optional HTTP basic authentication on the image server. Requires `HTTP_AUTH_PASSWORD` to enable authentication.                                                                          |
-| `HTTP_AUTH_PASSWORD`      | `secret`                              | no       | no       | Password for optional HTTP basic authentication on the image server. Requires `HTTP_AUTH_USER` to enable authentication.                                                                              |
+| `HTTP_AUTH_USER`          | `admin`                               | no       | yes      | Username for optional HTTP basic authentication on the image server. Requires `HTTP_AUTH_PASSWORD` to enable authentication.                                                                          |
+| `HTTP_AUTH_PASSWORD`      | `secret`                              | no       | yes      | Password for optional HTTP basic authentication on the image server. Requires `HTTP_AUTH_USER` to enable authentication.                                                                              |
 | `LANGUAGE`                | `en`                                  | no       | yes      | Language to set in browser and home assistant                                                                                                                                                        |
 | `PREFERS_COLOR_SCHEME`    | `light`                               | no       | yes      | Enable browser dark mode, use `light` or `dark`.                                                                                                                                                     |
 | `CRON_JOB`                | `* * * * *`                           | no       | no       | How often to take screenshot                                                                                                                                                                         |
@@ -89,6 +89,8 @@ Home Assistant related stuff:
 
 **\* Array** means that you can append `_2`, `_3`, ... `_n` for a numbered output page. Numbered variables fall back to the unnumbered value when omitted. For example, `ROTATION_2=180` only changes the second image; without it, the second image uses `ROTATION`.
 You can access these additional images by making GET Requests `http://localhost:5000/2`, `http://localhost:5000/3` etc.
+
+Numbered HTTP Basic Auth credentials protect the corresponding image and render endpoint. For example, `HTTP_AUTH_USER_3` and `HTTP_AUTH_PASSWORD_3` apply to `/3` and `/render/3`. When omitted, that page inherits `HTTP_AUTH_USER` and `HTTP_AUTH_PASSWORD`; global operations such as `/render` and `/cache/clear` use the unnumbered credentials. The `/health` endpoint remains unauthenticated for container health checks.
 
 ### Multiple Home Assistant instances
 

--- a/config.js
+++ b/config.js
@@ -59,6 +59,9 @@ function getPagesConfig() {
       batteryWebHook: getEnvironmentVariable("HA_BATTERY_WEBHOOK", suffix) || null,
       saturation: getEnvironmentVariable("SATURATION", suffix) || 1,
       contrast: getEnvironmentVariable("CONTRAST", suffix) || 1,
+      httpAuthUser: getEnvironmentVariable("HTTP_AUTH_USER", suffix) || null,
+      httpAuthPassword:
+        getEnvironmentVariable("HTTP_AUTH_PASSWORD", suffix) || null,
     });
   }
   return pages;

--- a/config.test.mjs
+++ b/config.test.mjs
@@ -8,12 +8,19 @@ const managedEnvironmentVariables = [
   "HA_BASE_URL_2",
   "HA_SCREENSHOT_URL",
   "HA_SCREENSHOT_URL_2",
+  "HA_SCREENSHOT_URL_3",
   "HA_ACCESS_TOKEN",
   "HA_ACCESS_TOKEN_2",
   "HA_THEME",
   "HA_THEME_2",
   "LANGUAGE",
-  "LANGUAGE_2"
+  "LANGUAGE_2",
+  "HTTP_AUTH_USER",
+  "HTTP_AUTH_USER_2",
+  "HTTP_AUTH_USER_3",
+  "HTTP_AUTH_PASSWORD",
+  "HTTP_AUTH_PASSWORD_2",
+  "HTTP_AUTH_PASSWORD_3"
 ];
 const originalEnvironment = Object.fromEntries(
   managedEnvironmentVariables.map((key) => [key, process.env[key]])
@@ -116,6 +123,27 @@ describe("config", () => {
       accessToken: "second-token",
       language: "fr",
       theme: { theme: "night" }
+    });
+  });
+
+  it("allows numbered pages to override inherited HTTP auth credentials", () => {
+    process.env.HA_SCREENSHOT_URL = "/lovelace/first";
+    process.env.HA_SCREENSHOT_URL_2 = "/lovelace/second";
+    process.env.HA_SCREENSHOT_URL_3 = "/lovelace/third";
+    process.env.HTTP_AUTH_USER = "shared-user";
+    process.env.HTTP_AUTH_PASSWORD = "shared-password";
+    process.env.HTTP_AUTH_USER_3 = "third-user";
+    process.env.HTTP_AUTH_PASSWORD_3 = "third-password";
+
+    const config = loadConfig();
+
+    expect(config.pages[1]).toMatchObject({
+      httpAuthUser: "shared-user",
+      httpAuthPassword: "shared-password"
+    });
+    expect(config.pages[2]).toMatchObject({
+      httpAuthUser: "third-user",
+      httpAuthPassword: "third-password"
     });
   });
 });

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Lovelace Kindle Screensaver
-version: 1.1.0
+version: 1.2.0
 slug: kindle-screensaver
 description: This tool can be used to display a Lovelace view of your Home Assistant instance on a jailbroken Kindle device. It regularly takes a screenshot which can be polled and used as a screensaver image of the online screensaver plugin.
 startup: application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       # Uncomment both HTTP_AUTH_* variables to require basic auth for the image endpoint.
       # - HTTP_AUTH_USER=admin
       # - HTTP_AUTH_PASSWORD=secret
+      # Add matching numbered variables for page-specific credentials, for example:
+      # - HTTP_AUTH_USER_2=second-admin
+      # - HTTP_AUTH_PASSWORD_2=second-secret
       - CRON_JOB=* * * * *
       - RENDERING_TIMEOUT=30000
       - RENDERING_DELAY=0

--- a/http-auth.js
+++ b/http-auth.js
@@ -1,0 +1,39 @@
+const unauthorizedHeaders = {
+  "WWW-Authenticate": 'Basic realm="hass-lovelace-kindle-screensaver"'
+};
+
+function getPageNumberForRequest(pathname) {
+  if (pathname === "/") return 1;
+
+  const match = pathname.match(/^\/(?:render\/)?([1-9]\d*)$/);
+  return match ? parseInt(match[1], 10) : 1;
+}
+
+function getHttpAuthForRequest(pathname, pages) {
+  const pageNumber = getPageNumberForRequest(pathname);
+  return pages[pageNumber - 1] || pages[0] || {};
+}
+
+function isHttpRequestAuthorized(authHeader, authConfig) {
+  if (!authConfig.httpAuthUser || !authConfig.httpAuthPassword) return true;
+  if (!authHeader || !authHeader.startsWith("Basic ")) return false;
+
+  const credentials = Buffer.from(authHeader.slice(6), "base64").toString();
+  const [user, ...passwordParts] = credentials.split(":");
+  const password = passwordParts.join(":");
+  return (
+    user === authConfig.httpAuthUser &&
+    password === authConfig.httpAuthPassword
+  );
+}
+
+function writeUnauthorizedResponse(response) {
+  response.writeHead(401, unauthorizedHeaders);
+  response.end("Unauthorized");
+}
+
+module.exports = {
+  getHttpAuthForRequest,
+  isHttpRequestAuthorized,
+  writeUnauthorizedResponse
+};

--- a/http-auth.test.mjs
+++ b/http-auth.test.mjs
@@ -1,0 +1,45 @@
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { getHttpAuthForRequest, isHttpRequestAuthorized } = require("./http-auth");
+
+const pages = [
+  { httpAuthUser: "first-user", httpAuthPassword: "first-password" },
+  { httpAuthUser: "second-user", httpAuthPassword: "second-password" },
+  { httpAuthUser: "third-user", httpAuthPassword: "third:password" }
+];
+
+function basicAuth(user, password) {
+  return `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+}
+
+describe("HTTP auth", () => {
+  it("selects numbered credentials for image and page render requests", () => {
+    expect(getHttpAuthForRequest("/3", pages)).toBe(pages[2]);
+    expect(getHttpAuthForRequest("/render/3", pages)).toBe(pages[2]);
+    expect(getHttpAuthForRequest("/render", pages)).toBe(pages[0]);
+    expect(getHttpAuthForRequest("/cache/clear", pages)).toBe(pages[0]);
+  });
+
+  it("authorizes a numbered page with its own username and password", () => {
+    const authConfig = getHttpAuthForRequest("/3", pages);
+
+    expect(
+      isHttpRequestAuthorized(basicAuth("third-user", "third:password"), authConfig)
+    ).toBe(true);
+    expect(
+      isHttpRequestAuthorized(
+        basicAuth("first-user", "first-password"),
+        authConfig
+      )
+    ).toBe(false);
+  });
+
+  it("leaves pages without a complete credential pair public", () => {
+    expect(isHttpRequestAuthorized(undefined, {})).toBe(true);
+    expect(
+      isHttpRequestAuthorized(undefined, { httpAuthUser: "user" })
+    ).toBe(true);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ const gm = require("gm");
 const crypto = require("crypto");
 const { shouldReturnNotModified } = require("./http-cache");
 const {
+  getHttpAuthForRequest,
+  isHttpRequestAuthorized,
+  writeUnauthorizedResponse
+} = require("./http-auth");
+const {
   getGraphicsMagickFormat,
   resolveFinalTempPath,
   resolveOutputPath,
@@ -195,8 +200,10 @@ async function getFileHash(filePath) {
     );
   };
 
-  const requireAuth = config.httpAuthUser && config.httpAuthPassword;
-  if (requireAuth) {
+  const hasProtectedPage = config.pages.some(
+    (pageConfig) => pageConfig.httpAuthUser && pageConfig.httpAuthPassword
+  );
+  if (hasProtectedPage) {
     console.log("Basic auth enabled for HTTP server");
   }
 
@@ -234,22 +241,12 @@ async function getFileHash(filePath) {
       return;
     }
 
-    // Check basic auth if configured
-    if (requireAuth) {
-      const authHeader = request.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Basic ")) {
-        response.writeHead(401, { "WWW-Authenticate": 'Basic realm="hass-lovelace-kindle-screensaver"' });
-        response.end("Unauthorized");
-        return;
-      }
-      const credentials = Buffer.from(authHeader.slice(6), "base64").toString();
-      const [user, ...passwordParts] = credentials.split(":");
-      const password = passwordParts.join(":");
-      if (user !== config.httpAuthUser || password !== config.httpAuthPassword) {
-        response.writeHead(401, { "WWW-Authenticate": 'Basic realm="hass-lovelace-kindle-screensaver"' });
-        response.end("Unauthorized");
-        return;
-      }
+    // Check the credentials configured for the requested page. Global operations
+    // such as /render and /cache/clear use the first page's credentials.
+    const requestAuth = getHttpAuthForRequest(url.pathname, config.pages);
+    if (!isHttpRequestAuthorized(request.headers.authorization, requestAuth)) {
+      writeUnauthorizedResponse(response);
+      return;
     }
 
     if (url.pathname === "/render" || url.pathname.startsWith("/render/")) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-lovelace-kindle-screensaver",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "cron": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-lovelace-kindle-screensaver",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,8 @@ bashio::log.info "Loading config..."
 export HA_BASE_URL="$(bashio::config 'HA_BASE_URL')"
 export HA_SCREENSHOT_URL=$(bashio::config 'HA_SCREENSHOT_URL')
 export HA_ACCESS_TOKEN="$(bashio::config 'HA_ACCESS_TOKEN')"
+export HTTP_AUTH_USER="$(bashio::config 'HTTP_AUTH_USER')"
+export HTTP_AUTH_PASSWORD="$(bashio::config 'HTTP_AUTH_PASSWORD')"
 export LANGUAGE=$(bashio::config 'LANGUAGE')
 export CRON_JOB=$(bashio::config 'CRON_JOB')
 export RENDERING_TIMEOUT=$(bashio::config 'RENDERING_TIMEOUT')


### PR DESCRIPTION
## Summary

- resolve HTTP Basic Auth credentials per numbered output page, including /3 and /render/3
- inherit unnumbered credentials when a numbered pair is omitted
- keep global operations on the unnumbered credentials and keep /health public
- export HTTP auth options in the Home Assistant Add-On launcher
- document page-specific credentials in the README and Docker Compose example

## Release preparation

- bump package and Home Assistant Add-On versions from 1.1.0 to 1.2.0
- add 1.2.0 changelog entries

## Validation

- npm test (27 tests passed)
- node --check config.js http-auth.js index.js
- bash -n run.sh
- git diff --check
- missing-configuration startup exits with the expected Please check your configuration message